### PR TITLE
Rework memory usage, allocation strategy and introduce on demand lexing and parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ PG := ./examples/hello-world.garden
 all: release
 
 DEBUG_EXTRA := -DDEBUG=1 -fsanitize=address,undefined -g3
+TEST_EXTRA := -fsanitize=address,undefined -g3
 RELEASE_EXTRA := -DCOMMIT='"$(COMMIT)"' -DCOMMIT_MSG='"$(COMMIT_MSG)"'
 BENCH_EXTRA := -DCOMMIT='"BENCH"'
 
@@ -75,8 +76,8 @@ $(BENCH_BIN): LINK_FLAGS := $(RELEASE_FLAGS) $(BENCH_EXTRA)
 $(BENCH_BIN): $(OBJ) | $(BIN_DIR)
 	$(CC) $(FLAGS) $(LINK_FLAGS) $^ -o $@
 
-$(TEST_BIN): COMPILE_FLAGS := 
-$(TEST_BIN): LINK_FLAGS := 
+$(TEST_BIN): COMPILE_FLAGS := $(TEST_EXTRA)
+$(TEST_BIN): LINK_FLAGS := $(TEST_EXTRA)
 $(TEST_BIN): $(TEST_OBJ) | $(BIN_DIR)
 	$(CC) $(FLAGS) $(LINK_FLAGS) $^ -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 FLAGS := -std=c23 \
-        -Wall -Wextra -Werror -fdiagnostics-color=always \
+        -Wall -Wextra -Werror -fno-diagnostics-color \
         -fno-common -Winit-self -Wfloat-equal -Wundef -Wshadow \
         -Wpointer-arith -Wcast-align -Wstrict-prototypes \
         -Wstrict-overflow=5 -Wwrite-strings -Waggregate-return \
@@ -75,7 +75,6 @@ $(BENCH_BIN): LINK_FLAGS := $(RELEASE_FLAGS) $(BENCH_EXTRA)
 $(BENCH_BIN): $(OBJ) | $(BIN_DIR)
 	$(CC) $(FLAGS) $(LINK_FLAGS) $^ -o $@
 
-# Test build (just reuse debug compile flags if needed)
 $(TEST_BIN): COMPILE_FLAGS := 
 $(TEST_BIN): LINK_FLAGS := 
 $(TEST_BIN): $(TEST_OBJ) | $(BIN_DIR)

--- a/adts.c
+++ b/adts.c
@@ -1,8 +1,10 @@
 #include "adts.h"
 
+#include <string.h>
+
+#include "cc.h"
 #include "common.h"
 #include "mem.h"
-#include <string.h>
 
 List List_new(size_t cap, Allocator *a) {
   List l = {
@@ -13,30 +15,36 @@ List List_new(size_t cap, Allocator *a) {
   return l;
 }
 
-void List_append(List *l, Value v, Allocator *a) {
+static void grow(List *l, Allocator *a, size_t to_grow_to) {
+  size_t old_cap = l->cap;
+  size_t new_cap = to_grow_to;
+
+  Value *new_mem = CALL(a, request, new_cap * sizeof(Value));
+  ASSERT(new_mem != NULL, "List growth failed: %zu -> %zu", old_cap, new_cap);
+
+  memcpy(new_mem, l->elements, old_cap * sizeof(Value));
+  l->elements = (struct Value *)new_mem;
+  l->cap = new_cap;
+}
+
+void List_append(List *l, Allocator *a, Value v) {
   if (l->len >= l->cap) {
-    size_t old_cap = l->cap;
-    size_t new_cap = old_cap * 2;
-
-    Value *new_mem = CALL(a, request, new_cap * sizeof(Value));
-    ASSERT(new_mem != NULL, "List growth failed: %zu -> %zu", old_cap, new_cap);
-
-    memcpy(new_mem, l->elements, old_cap * sizeof(Value));
-    l->elements = (struct Value *)new_mem;
-    l->cap = new_cap;
+    grow(l, a, l->cap * LIST_GROW_MULTIPLIER);
   }
 
   l->elements[l->len++] = v;
 }
 
-// V_NONE guarded checked access to the inner elements
-Value List_get(const List *l, size_t idx) {
-  if (idx >= l->len) {
-    return *INTERNED_NONE;
-  }
+Value List_get(const List *l, size_t idx) { return l->elements[idx]; }
 
-  Value v = l->elements[idx];
-  return v;
+void List_insert(List *l, Allocator *a, size_t idx, Value v) {
+  // we cant insert where we havent allocated, we need to grow until we are
+  // l->cap > idx
+  if (l->cap < idx) {
+    size_t new_cap = (size_t)(MAX(l->cap, idx + 1) * LIST_GROW_MULTIPLIER);
+    grow(l, a, new_cap);
+  }
+  l->elements[idx] = v;
 }
 
 // TODO: implement before adding support for V_OBJ

--- a/adts.c
+++ b/adts.c
@@ -2,7 +2,6 @@
 
 #include <string.h>
 
-#include "cc.h"
 #include "common.h"
 #include "mem.h"
 
@@ -22,6 +21,7 @@ static void grow(List *l, Allocator *a, size_t to_grow_to) {
   Value *new_mem = CALL(a, request, new_cap * sizeof(Value));
   ASSERT(new_mem != NULL, "List growth failed: %zu -> %zu", old_cap, new_cap);
 
+  // sadly we gotta copy, since we own all values :(
   memcpy(new_mem, l->elements, old_cap * sizeof(Value));
   l->elements = (struct Value *)new_mem;
   l->cap = new_cap;
@@ -47,8 +47,17 @@ void List_insert(List *l, Allocator *a, size_t idx, Value v) {
   l->elements[idx] = v;
 }
 
-// TODO: implement before adding support for V_OBJ
-Map Map_new(size_t cap, Allocator *a);
+Map Map_new(size_t cap, Allocator *a) {
+  // TODO: deal with collisions
+  // TODO: figure out a good default size, 8, 16, 32, 64?
+  // TODO: how does one grow a map, does every key need rehashing?
+  // TODO: should the buckets really be an "array" of Lists? Or does this need a
+  // different internal representation since I want to use it for things like
+  // @std/encoding/json, etc; maybe namespaces need to be implemented
+  // differently from V_OBJ?
+  return (Map){};
+}
+
 void Map_insert(Map *m, Str *s, Value v, Allocator *a);
 Value *Map_get(const Map *m, Str *s);
 bool Map_has(const Map *m, Str *s);

--- a/adts.h
+++ b/adts.h
@@ -9,8 +9,9 @@
 #define LIST_GROW_MULTIPLIER 1.5f
 
 List List_new(size_t cap, Allocator *a);
-void List_append(List *l, Value v, Allocator *a);
+void List_append(List *l, Allocator *a, Value v);
 Value List_get(const List *l, size_t idx);
+void List_insert(List *l, Allocator *a, size_t idx, Value v);
 
 #define MAP_DEFAULT_SIZE 16
 #define MAP_GROW_MULTIPLIER 1.5f

--- a/bcb.c
+++ b/bcb.c
@@ -1,0 +1,37 @@
+#include "adts.h"
+#include "cc.h"
+#include "common.h"
+#include "mem.h"
+
+ByteCodeBuilder ByteCodeBuilder_new(Allocator *a) {
+  size_t cap = INIT_BYTECODE_SIZE;
+  return (ByteCodeBuilder){
+      .alloc = a,
+      .cap = cap,
+      .buffer = (uint32_t *)CALL(a, request, cap * sizeof(uint32_t)),
+      .len = 0,
+  };
+}
+
+static void grow(ByteCodeBuilder *bcb, Allocator *a) {
+  size_t new_cap = bcb->cap * LIST_GROW_MULTIPLIER;
+  uint32_t *old = bcb->buffer;
+  bcb->buffer = CALL(a, request, sizeof(uint32_t) * new_cap);
+  memcpy(bcb->buffer, old, sizeof(uint32_t) * bcb->len);
+  bcb->cap = new_cap;
+}
+
+void ByteCodeBuilder_add(ByteCodeBuilder *bcb, uint32_t op, uint32_t arg) {
+  if (bcb->len + 2 > bcb->cap) {
+    grow(bcb, bcb->alloc);
+  }
+
+  bcb->buffer[bcb->len++] = op;
+  bcb->buffer[bcb->len++] = arg;
+}
+
+void ByteCodeBuilder_insert_arg(ByteCodeBuilder *bcb, size_t idx,
+                                uint32_t arg) {
+  ASSERT(idx + 1 < bcb->len, "Can't insert out of allocation bounds");
+  bcb->buffer[idx + 1] = arg;
+}

--- a/builtins.c
+++ b/builtins.c
@@ -16,7 +16,7 @@ static void print_value(const Value *v) {
     printf("%g", v->floating);
     break;
   case V_INT:
-    printf("%lld", v->integer);
+    printf("%ld", v->integer);
     break;
   case V_TRUE:
     printf("true");

--- a/bump.c
+++ b/bump.c
@@ -73,17 +73,6 @@ void bump_destroy(void *ctx) {
   free(ctx);
 }
 
-static inline uint64_t pow_ui(uint64_t base, uint64_t exp) {
-  uint64_t result = 1;
-  while (exp) {
-    if (exp & 1)
-      result *= base;
-    base *= base;
-    exp >>= 1;
-  }
-  return result;
-}
-
 Stats bump_stats(void *ctx) {
   BumpCtx *b_ctx = (BumpCtx *)ctx;
   return (Stats){.allocated = b_ctx->total_allocated,

--- a/bump.c
+++ b/bump.c
@@ -23,12 +23,7 @@ void *bump_request(void *ctx, size_t size) {
   size_t align = sizeof(void *);
   b_ctx->pos = (b_ctx->pos + align - 1) & ~(align - 1);
 
-  // We are OOM as specified by bump_init(max, ...)
-  if (b_ctx->max != 0 && b_ctx->pos + size >= b_ctx->max) {
-    // TODO: every call to bump_request must be checked for NULL after this
-    // change, otherwise nullpointer access + deref
-    return NULL;
-  }
+  ASSERT(!(b_ctx->max != 0 && b_ctx->pos + size < b_ctx->max), "OOM - WTF");
 
   if (b_ctx->pos + size > b_ctx->size) {
     size_t new_len = b_ctx->size * 2;

--- a/bump.c
+++ b/bump.c
@@ -11,26 +11,36 @@ typedef struct {
   // will hand out aligned chunks
   void *block;
   // the size of said allocated block
-  size_t len;
+  size_t size;
   // the current amount of bytes in use
   size_t pos;
-} BumpResizeCtx;
+  // the max amount the bump alloc should grow to
+  size_t max;
+} BumpCtx;
 
 void *bump_request(void *ctx, size_t size) {
-  BumpResizeCtx *b_ctx = ctx;
+  BumpCtx *b_ctx = ctx;
   size_t align = sizeof(void *);
   b_ctx->pos = (b_ctx->pos + align - 1) & ~(align - 1);
 
-  if (b_ctx->pos + size > b_ctx->len) {
-    size_t new_len = b_ctx->len * 2;
+  // We are OOM as specified by bump_init(max, ...)
+  if (b_ctx->max != 0 && b_ctx->pos + size >= b_ctx->max) {
+    // TODO: every call to bump_request must be checked for NULL after this
+    // change, otherwise nullpointer access + deref
+    return NULL;
+  }
+
+  if (b_ctx->pos + size > b_ctx->size) {
+    size_t new_len = b_ctx->size * 2;
     while (new_len < b_ctx->pos + size) {
       new_len *= 2;
     }
 
-    void *new_block = mremap(b_ctx->block, b_ctx->len, new_len, MREMAP_MAYMOVE);
+    void *new_block =
+        mremap(b_ctx->block, b_ctx->size, new_len, MREMAP_MAYMOVE);
     ASSERT(new_block != MAP_FAILED, "mremap failed");
     b_ctx->block = new_block;
-    b_ctx->len = new_len;
+    b_ctx->size = new_len;
   }
 
   void *block_entry = (char *)b_ctx->block + b_ctx->pos;
@@ -40,31 +50,32 @@ void *bump_request(void *ctx, size_t size) {
 
 void bump_destroy(void *ctx) {
   ASSERT(ctx != NULL, "bump_destroy on already destroyed allocator");
-  BumpResizeCtx *b_ctx = (BumpResizeCtx *)ctx;
-  madvise(b_ctx->block, b_ctx->len, MADV_FREE);
-  int res = munmap(b_ctx->block, b_ctx->len);
+  BumpCtx *b_ctx = (BumpCtx *)ctx;
+  madvise(b_ctx->block, b_ctx->size, MADV_FREE);
+  int res = munmap(b_ctx->block, b_ctx->size);
   ASSERT(res == 0, "munmap failed");
   free(ctx);
 }
 
 Stats bump_stats(void *ctx) {
-  BumpResizeCtx *b_ctx = (BumpResizeCtx *)ctx;
-  return (Stats){.allocated = b_ctx->len, .current = b_ctx->pos};
+  BumpCtx *b_ctx = (BumpCtx *)ctx;
+  return (Stats){.allocated = b_ctx->size, .current = b_ctx->pos};
 }
 
-Allocator *bump_init(size_t size) {
+Allocator *bump_init(size_t min_size, size_t max_size) {
   long page_size = sysconf(_SC_PAGESIZE);
-  size = (size + page_size - 1) & ~(page_size - 1);
+  size_t size = (min_size + page_size - 1) & ~(page_size - 1);
 
   void *b = mmap(NULL, size, PROT_READ | PROT_WRITE,
                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   ASSERT(b != MAP_FAILED, "failed to mmap allocator buffer");
 
-  BumpResizeCtx *ctx = malloc(sizeof(BumpResizeCtx));
+  BumpCtx *ctx = malloc(sizeof(BumpCtx));
   ASSERT(ctx != NULL, "failed to bump allocator context");
-  ctx->len = size;
+  ctx->size = size;
   ctx->pos = 0;
   ctx->block = b;
+  ctx->max = max_size;
 
   Allocator *a = malloc(sizeof(Allocator));
   ASSERT(a != NULL, "failed to alloc bump allocator");

--- a/cc.c
+++ b/cc.c
@@ -426,6 +426,10 @@ Ctx cc(Vm *vm, Allocator *alloc, Parser *p) {
     if (n.type == N_UNKNOWN) {
       break;
     }
+#if DEBUG
+    Node_debug(&n, 0);
+    puts("");
+#endif
     compile(alloc, vm, &ctx, &n);
   }
 

--- a/cc.c
+++ b/cc.c
@@ -46,6 +46,7 @@ inline static Value *token_to_value(Token *t, Allocator *a) {
     ASSERT(0, "Unsupported value for token_to_value");
     break;
   }
+
   return v;
 }
 
@@ -73,14 +74,9 @@ static size_t runtime_builtin_hashes[MAX_BUILTIN_SIZE + 1];
 
 static void compile(Allocator *alloc, Vm *vm, Ctx *ctx, Node *n) {
   switch (n->type) {
-  case N_ATOM: {
-    // interning logic, global pool 0 is the only instance for false in the
-    // runtime, 1 for true, strings get interned by their hashes, doubles by
-    // their bits and ints by their integer representation
-
+  case N_ATOM: { // TODO: this works but not good enough and its somewhat silly
+                 // to think we wouldnt need a collision strategy for buckets
 // High tag bits
-#define TAG_FALSE 0x1000000000000000ULL
-#define TAG_TRUE 0x2000000000000000ULL
 #define TAG_STRING 0x3000000000000000ULL
 #define TAG_DOUBLE 0x4000000000000000ULL
 #define TAG_INT 0x5000000000000000ULL
@@ -98,7 +94,6 @@ static void compile(Allocator *alloc, Vm *vm, Ctx *ctx, Node *n) {
     } else if (n->token->type == T_STRING) {
       hash = TAG_STRING | (n->token->string.hash & TAG_MASK);
     } else if (n->token->type == T_DOUBLE) {
-      // type punning by using token->integer while token->floating is filled
       hash = TAG_DOUBLE | (n->token->string.hash & TAG_MASK);
     } else if (n->token->type == T_INTEGER) {
       hash = TAG_INT | (n->token->string.hash & TAG_MASK);

--- a/cc.c
+++ b/cc.c
@@ -84,7 +84,7 @@ static void compile(Allocator *alloc, Vm *vm, Ctx *ctx, Node *n) {
 // Tag mask to keep lower bits
 #define TAG_MASK 0x0FFFFFFFFFFFFFFFULL
 
-    size_t hash;
+    size_t hash = 0;
     if (n->token->type == T_FALSE) {
       BC(OP_LOADG, GLOBAL_FALSE);
       break;

--- a/cc.c
+++ b/cc.c
@@ -348,6 +348,7 @@ static void compile(Allocator *alloc, Vm *vm, Ctx *ctx, Node *n) {
       registers[i] = r;
       BC(OP_STORE, r);
     }
+
     for (int i = n->children_length - 1; i >= 0; i--) {
       Ctx_free_register(ctx, registers[i]);
     }

--- a/cc.c
+++ b/cc.c
@@ -430,11 +430,23 @@ Ctx cc(Vm *vm, Allocator *alloc, Parser *p) {
     if (n.type == N_UNKNOWN) {
       break;
     }
+
+    if (n.type == N_ROOT) {
+      for (size_t i = 0; i < n.children_length; i++) {
 #if DEBUG
-    Node_debug(&n, 0);
-    puts("");
+        Node_debug(&n, 0);
+        puts("");
 #endif
-    compile(alloc, vm, &ctx, &n);
+        compile(alloc, vm, &ctx, n.children[i]);
+      }
+      break;
+    } else {
+#if DEBUG
+      Node_debug(&n, 0);
+      puts("");
+#endif
+      compile(alloc, vm, &ctx, &n);
+    }
   }
 
   ASSERT(ctx.register_allocated_count == 1,

--- a/cc.c
+++ b/cc.c
@@ -339,8 +339,9 @@ static void compile(Allocator *alloc, Vm *vm, Ctx *ctx, Node *n) {
       return;
     }
 
+    size_t children_length = n->children_length < 1 ? 1 : n->children_length;
     // we compile all arguments to bytecode one by one by one
-    size_t registers[n->children_length];
+    size_t registers[children_length];
     for (size_t i = 0; i < n->children_length; i++) {
       compile(alloc, vm, ctx, n->children[i]);
       size_t r = Ctx_allocate_register(ctx);

--- a/cc.h
+++ b/cc.h
@@ -8,13 +8,8 @@
 #define DISASSEMBLE_INCLUDE_POSITIONS 0
 #endif
 
-#define BC(CODE, ARG)                                                          \
-  vm->bytecode[vm->bytecode_len++] = CODE;                                     \
-  vm->bytecode[vm->bytecode_len++] = ARG;                                      \
-  ASSERT(vm->bytecode_len <= BYTECODE_SIZE,                                    \
-         "cc: out of bytecode space, what the fuck are you doing");
-
-#define GROW_FACTOR 2
+#define BC(CODE, ARG) ByteCodeBuilder_add(ctx->bcb, CODE, ARG)
+#define BC_LEN ctx->bcb->len
 
 typedef enum {
   COMPILE_BUILTIN_UNKNOWN = 0,
@@ -32,11 +27,27 @@ typedef struct CtxFunction {
   size_t argument_count;
 } CtxFunction;
 
+// ByteCodeBuilder is used to efficiently build the buffer necessary for
+// bytecode storage
+typedef struct {
+  Allocator *alloc;
+  uint32_t *buffer;
+  size_t cap;
+  size_t len;
+} ByteCodeBuilder;
+ByteCodeBuilder ByteCodeBuilder_new(Allocator *a);
+void ByteCodeBuilder_add(ByteCodeBuilder *bcb, uint32_t op, uint32_t arg);
+void ByteCodeBuilder_insert_arg(ByteCodeBuilder *bcb, size_t idx, uint32_t arg);
+
+// Used internally in the compiler to keep track of the currently allocated
+// registers, what global slot is filled, what functions are defined by their
+// hashes
 typedef struct Ctx {
   bool registers[REGISTERS + 1];
   size_t *global_hash_buckets;
   size_t register_allocated_count;
   CtxFunction hash_to_function[MAX_BUILTIN_SIZE];
+  ByteCodeBuilder *bcb;
 } Ctx;
 
 // cc requests a Node from parser::Parser_next compiles said Node and its

--- a/cc.h
+++ b/cc.h
@@ -42,7 +42,7 @@ typedef struct Ctx {
 // cc requests a Node from parser::Parser_next compiles said Node and its
 // children to populate the Vm, its global pool, its bytecode and do all prep
 // the runtime requires
-Ctx cc(Vm *vm, Allocator *alloc, Node **nodes, size_t size);
+Ctx cc(Vm *vm, Allocator *alloc, Parser *p);
 
 // disassemble prints a readable bytecode representation with labels, globals
 // and comments as a heap allocated string

--- a/common.c
+++ b/common.c
@@ -84,7 +84,7 @@ void Value_debug(const Value *v) {
     printf("(%g)", v->floating);
     break;
   case V_INT:
-    printf("(%lld)", v->integer);
+    printf("(%ld)", v->integer);
     break;
   case V_OBJ:
     // TODO: V_OBJ

--- a/common.h
+++ b/common.h
@@ -22,6 +22,10 @@
       MAX_BUILTIN_SIZE * sizeof(builtin_function)
 #endif
 
+#ifndef MAX_MEM
+#define MAX_MEM (128 * 1024 * 1024)
+#endif
+
 #define REGISTERS 127
 #define CALL_ARGUMENT_STACK 256
 #define VARIABLE_TABLE_SIZE 256

--- a/common.h
+++ b/common.h
@@ -23,10 +23,6 @@
       MAX_BUILTIN_SIZE * sizeof(builtin_function)
 #endif
 
-#ifndef MAX_MEM
-#define MAX_MEM (128 * 1024 * 1024)
-#endif
-
 #define REGISTERS 127
 #define CALL_ARGUMENT_STACK 256
 #define VARIABLE_TABLE_SIZE 256

--- a/common.h
+++ b/common.h
@@ -10,14 +10,17 @@
 #define DEBUG 0
 #endif
 
-#ifndef MIN_MEM
-#define MIN_MEM 4 * 1024 * 1024
-#endif
-
-#define BYTECODE_SIZE (5 * 1024 * 1024)
-#define GLOBAL_SIZE 512 * 1024
+#define BYTECODE_SIZE (2 * 1024 * 1024)
+#define GLOBAL_SIZE 512
+#define GLOBAL_SIZE_MASK (GLOBAL_SIZE - 1)
 #define MAX_BUILTIN_SIZE 1024
 #define MAX_BUILTIN_SIZE_MASK (MAX_BUILTIN_SIZE - 1)
+
+#ifndef MIN_MEM
+#define MIN_MEM                                                                \
+  BYTECODE_SIZE * sizeof(uint32_t) + 2 * GLOBAL_SIZE * sizeof(Value) +         \
+      MAX_BUILTIN_SIZE * sizeof(builtin_function)
+#endif
 
 #define REGISTERS 127
 #define CALL_ARGUMENT_STACK 256

--- a/common.h
+++ b/common.h
@@ -10,7 +10,8 @@
 #define DEBUG 0
 #endif
 
-#define BYTECODE_SIZE (2 * 1024 * 1024)
+// 128 instruction pairs amount to around 1KB memory usage
+#define INIT_BYTECODE_SIZE 128 * 2
 #define GLOBAL_SIZE 512
 #define GLOBAL_SIZE_MASK (GLOBAL_SIZE - 1)
 #define MAX_BUILTIN_SIZE 1024
@@ -18,7 +19,7 @@
 
 #ifndef MIN_MEM
 #define MIN_MEM                                                                \
-  BYTECODE_SIZE * sizeof(uint32_t) + 2 * GLOBAL_SIZE * sizeof(Value) +         \
+  INIT_BYTECODE_SIZE * sizeof(uint32_t) + 2 * GLOBAL_SIZE * sizeof(Value) +    \
       MAX_BUILTIN_SIZE * sizeof(builtin_function)
 #endif
 
@@ -45,6 +46,8 @@
   fprintf(stderr, "TODO: " fmt " failed in " __FILE__ ":%d\n", ##__VA_ARGS__,  \
           __LINE__);                                                           \
   exit(EXIT_FAILURE);
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 #include "strings.h"
 

--- a/common.h
+++ b/common.h
@@ -23,7 +23,7 @@
       MAX_BUILTIN_SIZE * sizeof(builtin_function)
 #endif
 
-#define REGISTERS 127
+#define REGISTERS 31
 #define CALL_ARGUMENT_STACK 256
 #define VARIABLE_TABLE_SIZE 256
 #define VARIABLE_TABLE_SIZE_MASK (VARIABLE_TABLE_SIZE - 1)

--- a/dis.c
+++ b/dis.c
@@ -11,7 +11,7 @@ void disassemble(const Vm *vm, const Ctx *ctx) {
       Value_debug(v);
       printf("; {idx=%zu", i);
       if (v->type == V_STR) {
-        printf(",hash=%zu", v->string.hash & GLOBAL_MASK);
+        printf(",hash=%zu", v->string.hash & GLOBAL_SIZE_MASK);
       }
       printf("}\n\t");
     }

--- a/dis.c
+++ b/dis.c
@@ -11,7 +11,7 @@ void disassemble(const Vm *vm, const Ctx *ctx) {
       Value_debug(v);
       printf("; {idx=%zu", i);
       if (v->type == V_STR) {
-        printf(",hash=%llu", v->string.hash & GLOBAL_SIZE_MASK);
+        printf(",hash=%lu", v->string.hash & GLOBAL_SIZE_MASK);
       }
       printf("}\n\t");
     }

--- a/examples/functions.garden
+++ b/examples/functions.garden
@@ -15,7 +15,6 @@
 (greeting "user")
 
 ;; tail calls 
-;; BUG: this seems buggy
 (@fn inc [x] (+ x 1))
 (@fn call1 [x] (inc x))
 (@fn call2 [x] (call1 x))

--- a/examples/functions.garden
+++ b/examples/functions.garden
@@ -14,18 +14,15 @@
 (@fn greeting [greetee] (@println "hello world to:" greetee))
 (greeting "user")
 
-;; tail calls
+;; tail calls 
+;; BUG: this seems buggy
 (@fn inc [x] (+ x 1))
 (@fn call1 [x] (inc x))
 (@fn call2 [x] (call1 x))
 (@fn call3 [x] (call2 x))
 (@fn call4 [x] (call3 x))
 (@fn call5 [x] (call4 x))
-
 (@println (call5 0))
-
-(@fn hello [])
-(hello)
 
 (@fn tuplify [v] [(@type v) (@len v)])
 (@println (tuplify "hello world"))

--- a/examples/hello-world.garden
+++ b/examples/hello-world.garden
@@ -2,5 +2,4 @@
 
 ; @println is a predefined function responsible for writing to stdout 
 ; builtins are specifically called via @<builtin>
-(@fn hello [] ())
-(hello)
+(@println "Hello" "World")

--- a/examples/hello-world.garden
+++ b/examples/hello-world.garden
@@ -2,4 +2,4 @@
 
 ; @println is a predefined function responsible for writing to stdout 
 ; builtins are specifically called via @<builtin>
-(@println "Hello World")
+(@println "Hello" "World")

--- a/examples/hello-world.garden
+++ b/examples/hello-world.garden
@@ -2,4 +2,5 @@
 
 ; @println is a predefined function responsible for writing to stdout 
 ; builtins are specifically called via @<builtin>
-(@println "Hello" "World")
+(@fn hello [] ())
+(hello)

--- a/examples/hello-world.garden
+++ b/examples/hello-world.garden
@@ -2,4 +2,4 @@
 
 ; @println is a predefined function responsible for writing to stdout 
 ; builtins are specifically called via @<builtin>
-(@println "Hello" "World")
+(@println "Hello World")

--- a/examples/values.garden
+++ b/examples/values.garden
@@ -23,7 +23,7 @@
   ; same type lists
   [1 2 3 4 5 6]
   ; different type lists
-  [1 "hello" "world" true]
+  [1 "hello" "world" true false]
 )
 
 ;; objects

--- a/lexer.c
+++ b/lexer.c
@@ -44,7 +44,7 @@ void Token_debug(Token *token) {
   case T_IDENT:
     putc('[', stdout);
     Str_debug(&token->string);
-    printf("]{.hash=%llu}", token->string.hash);
+    printf("]{.hash=%lu}", token->string.hash);
     break;
   case T_TRUE:
   case T_FALSE:

--- a/lexer.c
+++ b/lexer.c
@@ -87,6 +87,8 @@ Token *INTERN_TRUE = &SINGLE_TOK(T_TRUE);
 Token *INTERN_EQUAL = &SINGLE_TOK(T_EQUAL);
 Token *INTERN_EOF = &SINGLE_TOK(T_EOF);
 
+// TODO: lexer needs a hash based string and ident interning model, the current
+// falls apart after around 1 mio identifiers
 Token *Lexer_next(Lexer *l, Allocator *a) {
   // empty input
   if (l->input.len == 0) {

--- a/lexer.c
+++ b/lexer.c
@@ -31,8 +31,9 @@ Str TOKEN_TYPE_MAP[] = {[T_DELIMITOR_LEFT] = STRING("T_DELIMITOR_LEFT"),
 
 #if DEBUG
 void Token_debug(Token *token) {
+  ASSERT(token != NULL, "NULL token!");
   ASSERT(token->type <= T_EOF, "Out of bounds type, SHOULD NEVER HAPPEN");
-  putc('[', stdout);
+  printf("[");
   Str_debug(&TOKEN_TYPE_MAP[token->type]);
   putc(']', stdout);
   switch (token->type) {
@@ -247,13 +248,13 @@ ident: {
   }
 
   size_t len = l->pos - start;
-  Token *t;
+
   if (hash == l->true_hash) {
-    t = INTERN_TRUE;
+    return INTERN_TRUE;
   } else if (hash == l->false_hash) {
-    t = INTERN_FALSE;
+    return INTERN_FALSE;
   } else {
-    t = CALL(a, request, sizeof(Token));
+    Token *t = CALL(a, request, sizeof(Token));
     t->type = T_IDENT;
     t->string = (Str){
         .p = l->input.p + start,
@@ -261,7 +262,6 @@ ident: {
         .hash = hash,
     };
   }
-  return t;
 }
 
 // same as string but only with leading '

--- a/lexer.c
+++ b/lexer.c
@@ -43,7 +43,7 @@ void Token_debug(Token *token) {
   case T_IDENT:
     putc('[', stdout);
     Str_debug(&token->string);
-    putc(']', stdout);
+    printf("]{.hash=%zu}", token->string.hash);
     break;
   case T_TRUE:
   case T_FALSE:
@@ -165,7 +165,7 @@ builtin: {
     return INTERN_EOF;
   }
   size_t start = l->pos;
-  uint32_t hash = FNV_OFFSET_BASIS;
+  uint64_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && is_alphanum(cc); l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;
@@ -207,7 +207,7 @@ number: {
   size_t start = l->pos;
   size_t i = start;
   bool is_double = false;
-  uint32_t hash = FNV_OFFSET_BASIS;
+  uint64_t hash = FNV_OFFSET_BASIS;
   for (; i < l->input.len; i++) {
     char cc = l->input.p[i];
     hash ^= cc;
@@ -240,7 +240,7 @@ number: {
 
 ident: {
   size_t start = l->pos;
-  uint32_t hash = FNV_OFFSET_BASIS;
+  uint64_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && is_alphanum(cc); l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;
@@ -269,7 +269,7 @@ quoted: {
   // skip '
   l->pos++;
   size_t start = l->pos;
-  uint32_t hash = FNV_OFFSET_BASIS;
+  uint64_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && is_alphanum(cc); l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;
@@ -291,7 +291,7 @@ string: {
   // skip "
   l->pos++;
   size_t start = l->pos;
-  uint32_t hash = FNV_OFFSET_BASIS;
+  uint64_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && cc != '"'; l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;

--- a/lexer.c
+++ b/lexer.c
@@ -87,7 +87,6 @@ Token *INTERN_TRUE = &SINGLE_TOK(T_TRUE);
 Token *INTERN_EQUAL = &SINGLE_TOK(T_EQUAL);
 Token *INTERN_EOF = &SINGLE_TOK(T_EOF);
 
-// TODO: #5: rework this into Lexer_next
 size_t Lexer_all(Lexer *l, Allocator *a, Token **out) {
   ASSERT(out != NULL, "Failed to allocate token list");
 
@@ -103,7 +102,7 @@ size_t Lexer_all(Lexer *l, Allocator *a, Token **out) {
   //
   // we assign unknown to all and overwrite these to make sure an invalid
   // index is not a unassigned memory access.
-#pragma GCC diagnostic ignored "-Winitializer-overrides"
+#pragma GCC diagnostic ignored "-Woverride-init"
   static void *jump_table[256] = {
       [0 ... 255] = &&unknown,
       [' '] = &&whitespace,
@@ -353,5 +352,7 @@ end:
   out[count++] = INTERN_EOF;
   return count;
 }
+
+Token *Lexer_next(Lexer *l) { return INTERN_EOF; }
 
 #undef SINGLE_TOK

--- a/lexer.c
+++ b/lexer.c
@@ -165,7 +165,7 @@ builtin: {
     return INTERN_EOF;
   }
   size_t start = l->pos;
-  size_t hash = FNV_OFFSET_BASIS;
+  uint32_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && is_alphanum(cc); l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;
@@ -207,7 +207,7 @@ number: {
   size_t start = l->pos;
   size_t i = start;
   bool is_double = false;
-  size_t hash = FNV_OFFSET_BASIS;
+  uint32_t hash = FNV_OFFSET_BASIS;
   for (; i < l->input.len; i++) {
     char cc = l->input.p[i];
     hash ^= cc;
@@ -240,7 +240,7 @@ number: {
 
 ident: {
   size_t start = l->pos;
-  size_t hash = FNV_OFFSET_BASIS;
+  uint32_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && is_alphanum(cc); l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;
@@ -269,7 +269,7 @@ quoted: {
   // skip '
   l->pos++;
   size_t start = l->pos;
-  size_t hash = FNV_OFFSET_BASIS;
+  uint32_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && is_alphanum(cc); l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;
@@ -291,7 +291,7 @@ string: {
   // skip "
   l->pos++;
   size_t start = l->pos;
-  size_t hash = FNV_OFFSET_BASIS;
+  uint32_t hash = FNV_OFFSET_BASIS;
   for (char cc = cur(l); cc > 0 && cc != '"'; l->pos++, cc = cur(l)) {
     hash ^= cc;
     hash *= FNV_PRIME;

--- a/lexer.h
+++ b/lexer.h
@@ -65,4 +65,4 @@ typedef struct {
 } Lexer;
 
 Lexer Lexer_new(Str input);
-Token *Lexer_next(Lexer *l);
+Token *Lexer_next(Lexer *l, Allocator *a);

--- a/lexer.h
+++ b/lexer.h
@@ -58,8 +58,11 @@ void Token_debug(Token *token);
 typedef struct {
   Str input;
   size_t pos;
+
+  // precomputed hashes for faster boolean lookups
+  size_t true_hash;
+  size_t false_hash;
 } Lexer;
 
 Lexer Lexer_new(Str input);
-Token Lexer_next(Lexer *l);
-size_t Lexer_all(Lexer *l, Allocator *a, Token **out);
+Token *Lexer_next(Lexer *l);

--- a/main.c
+++ b/main.c
@@ -209,9 +209,9 @@ int main(int argc, char **argv) {
     VERBOSE_PUTS(
         "vm: got --block-allocator, using bump allocator with size %zuB/%zuKB",
         a.block_allocator * 1024, a.block_allocator);
-    vm.alloc = bump_init(a.block_allocator * 1024, MAX_MEM);
+    vm.alloc = bump_init(a.block_allocator * 1024, 0);
   } else {
-    vm.alloc = xcgc_init(GC_MIN_HEAP, &vm);
+    vm.alloc = xcgc_init(&vm, GC_MIN_HEAP, 0);
   }
   int runtime_code = Vm_run(&vm);
   VERBOSE_PUTS("vm::Vm_run: executed byte code");

--- a/main.c
+++ b/main.c
@@ -1,3 +1,4 @@
+// TODO: use pg.h as the debug entry point too.
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/main.c
+++ b/main.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
   // this allocator stores both nodes, bytecode and the global pool of the vm,
   // thus it has to life exactly as long as the vm does.
   //
-  Allocator *pipeline_allocator = bump_init(MIN_MEM);
+  Allocator *pipeline_allocator = bump_init(MIN_MEM, 0);
   VERBOSE_PUTS("mem::init: Allocated memory block of size=%zuB", MIN_MEM);
   Lexer lexer = Lexer_new(input);
   Parser parser = Parser_new(pipeline_allocator, &lexer);
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
     VERBOSE_PUTS(
         "vm: got --block-allocator, using bump allocator with size %zuB/%zuKB",
         a.block_allocator * 1024, a.block_allocator);
-    vm.alloc = bump_init(a.block_allocator * 1024);
+    vm.alloc = bump_init(a.block_allocator * 1024, MAX_MEM);
   } else {
     vm.alloc = xcgc_init(GC_MIN_HEAP, &vm);
   }

--- a/main.c
+++ b/main.c
@@ -111,6 +111,7 @@ Args Args_parse(int argc, char **argv) {
   }
   a.block_allocator = s.flags[__BLOCK_ALLOC].l;
   a.aot_functions = s.flags[__AOT].b;
+  // a.disassemble = s.flags[__DISASSEMBLE].b;
   a.disassemble = s.flags[__DISASSEMBLE].b;
   a.memory_usage = s.flags[__MEMORY_USAGE].b;
   a.run = s.flags[__RUN].s;

--- a/main.c
+++ b/main.c
@@ -167,6 +167,7 @@ int main(int argc, char **argv) {
   VERBOSE_PUTS("mem::init: Allocated memory block of size=%zuB", MIN_MEM);
   Lexer lexer = Lexer_new(input);
   Parser parser = Parser_new(pipeline_allocator, &lexer);
+
   // TODO: move this into parser::advance
   // VERBOSE_PUTS("lexer::Lexer_all: lexed tokens count=%zu (%zuB)", count,
   // count * sizeof(Token *));
@@ -178,6 +179,12 @@ int main(int argc, char **argv) {
   // alloc is NULL here, because we are setting it later on, depending on the
   // cli configuration
   Vm vm = Vm_new((Vm_Config){}, pipeline_allocator, NULL);
+  if (UNLIKELY(a.memory_usage)) {
+    Stats s = CALL(pipeline_allocator, stats);
+    double percent = (s.current * 100) / (double)s.allocated;
+    printf("vmnew: %.2fKB of %.2fKB used (%f%%)\n", s.current / 1024.0,
+           s.allocated / 1024.0, percent);
+  }
   Ctx ctx = cc(&vm, pipeline_allocator, &parser);
   VERBOSE_PUTS("cc::cc: Flattened AST to byte code/global pool length=%zu/%zu "
                "(%zuB/%zuB)",

--- a/mem.h
+++ b/mem.h
@@ -4,9 +4,9 @@
 #include <stddef.h>
 
 #ifdef DEBUG
-#if DEBUG
-#define VERBOSE_ALLOCATOR 1
-#endif
+// #if DEBUG
+// #define VERBOSE_ALLOCATOR 1
+// #endif
 #else
 #endif
 

--- a/mem.h
+++ b/mem.h
@@ -62,6 +62,6 @@ typedef struct {
 } Allocator;
 
 Allocator *bump_init(size_t min_size, size_t max_size);
-Allocator *xcgc_init(size_t size, void *vm);
+Allocator *xcgc_init(void *vm, size_t min_size, size_t max_size);
 
 #endif

--- a/mem.h
+++ b/mem.h
@@ -62,7 +62,7 @@ typedef struct {
   void (*destroy)(void *ctx);
 } Allocator;
 
-Allocator *bump_init(size_t size);
+Allocator *bump_init(size_t min_size, size_t max_size);
 Allocator *xcgc_init(size_t size, void *vm);
 
 #endif

--- a/mem.h
+++ b/mem.h
@@ -11,8 +11,8 @@
 #define VERBOSE_ALLOCATOR 0
 #endif
 
-// 1KB
-#define GC_MIN_HEAP 1024
+// 50KB
+#define GC_MIN_HEAP 50 * 1024
 
 typedef struct {
   size_t current;

--- a/mem.h
+++ b/mem.h
@@ -8,7 +8,6 @@
 #define VERBOSE_ALLOCATOR 1
 #endif
 #else
-#define VERBOSE_ALLOCATOR 0
 #endif
 
 // 50KB
@@ -24,7 +23,7 @@ typedef struct {
 // Allocator, which reduces alloc_bump.request(alloc_bump.ctx, 64); to
 // CALL(alloc_bump, request, 64), removing the need for passing the context in
 // manually
-#if VERBOSE_ALLOCATOR
+#ifdef VERBOSE_ALLOCATOR
 #include <stdio.h>
 #define CALL(SELF, METHOD, ...)                                                \
   (fprintf(stderr, "[ALLOCATOR] %s@%s::%d: %s->%s(%s)\n", __FILE__, __func__,  \

--- a/mem.h
+++ b/mem.h
@@ -5,14 +5,14 @@
 
 #ifdef DEBUG
 #if DEBUG
-#define VERBOSE_ALLOCATOR 0
+#define VERBOSE_ALLOCATOR 1
 #endif
 #else
 #define VERBOSE_ALLOCATOR 0
 #endif
 
-// 1MB
-#define GC_MIN_HEAP 1024 * 1024
+// 1KB
+#define GC_MIN_HEAP 1024
 
 typedef struct {
   size_t current;

--- a/parser.c
+++ b/parser.c
@@ -13,13 +13,17 @@ Parser Parser_new(Allocator *alloc, Lexer *l) {
       .alloc = alloc,
       .lexer = l,
       .pos = 0,
-      .cur = Lexer_next(l),
+      .cur = Lexer_next(l, alloc),
   };
 }
 
 static void advance(Parser *p) {
+#if DEBUG
+  Token_debug(p->cur);
+  puts("");
+#endif
   p->pos++;
-  p->cur = Lexer_next(p->lexer);
+  p->cur = Lexer_next(p->lexer, p->alloc);
 }
 
 static void consume(Parser *p, TokenType tt) {
@@ -52,7 +56,6 @@ static void Node_add_child(Allocator *alloc, Node *n, Node *child) {
   n->children[n->children_length++] = child;
 }
 
-// TODO: #5: restructure this to fit Parser_next
 size_t Parser_all(Node **nodes, Parser *p, size_t max_nodes) {
   // stack keeps the list(s) we are in, the last element is always the current
   // list, the first (0) is root
@@ -193,6 +196,11 @@ eof:
 }
 
 Node Parser_next(Parser *p) {
+  // TODO: remove this stub
+  while (p->cur->type != T_EOF) {
+    advance(p);
+  }
+
   return (Node){
       .type = N_UNKNOWN,
   };

--- a/parser.c
+++ b/parser.c
@@ -121,12 +121,6 @@ stmt_begin: {
   n->children_length = 0;
   n->children_cap = 0;
   consume(p, T_DELIMITOR_LEFT);
-  // BUG: there is a segfault here, triggerable via:
-  //
-  // (@fn hello [] ())
-  // (hello) * 1mio
-  //
-  // This may be an alloc failure in the bump allocator bump_request in line 120
   n->token = p->cur;
   switch (p->cur->type) {
   case T_BUILTIN:
@@ -209,12 +203,12 @@ obj_end: {
   JUMP_NEXT;
 }
 
-// we want to end or error here
-eof:
-  // TODO: this is buggy and needs a fix once im awake again
-  if (stack_top == 0) {
-    return *stack[0]->children[0];
-  }
+eof: // we dont have any more input, return stack top
+  Node *n = stack[stack_top];
+  ASSERT(n->children_length == 0, "Top level sexpr necessary");
+  return *n;
+
+// we want to error here
 unkown:
   return (Node){.type = N_UNKNOWN};
 }

--- a/parser.c
+++ b/parser.c
@@ -20,7 +20,7 @@ Parser Parser_new(Allocator *alloc, Lexer *l) {
 static void advance(Parser *p) {
 #if DEBUG
   Token_debug(p->cur);
-  puts("");
+  puts("hurensohn");
 #endif
   p->pos++;
   p->cur = Lexer_next(p->lexer, p->alloc);
@@ -95,7 +95,6 @@ Node Parser_next(Parser *p) {
 #define JUMP_NEXT goto *jump_table[p->cur->type];
 
   ASSERT(stack_top < MAX_DEPTH, "Stack overflow, max 256 stack depth");
-
   JUMP_NEXT;
 
 atom: {
@@ -118,9 +117,8 @@ ident: {
 
 stmt_begin: {
   Node *n = CALL(p->alloc, request, sizeof(Node));
-  n->children_length = 0;
-  n->children_cap = 0;
   consume(p, T_DELIMITOR_LEFT);
+  ASSERT(n != NULL, "IDK anymore");
   n->token = p->cur;
   switch (p->cur->type) {
   case T_BUILTIN:

--- a/parser.c
+++ b/parser.c
@@ -20,7 +20,7 @@ Parser Parser_new(Allocator *alloc, Lexer *l) {
 static void advance(Parser *p) {
 #if DEBUG
   Token_debug(p->cur);
-  puts("hurensohn");
+  puts("");
 #endif
   p->pos++;
   p->cur = Lexer_next(p->lexer, p->alloc);
@@ -239,7 +239,7 @@ void Node_debug(Node *n, size_t depth) {
   switch (n->type) {
   case N_IDENT:
     Token_debug(n->token);
-    printf("{idx=%llu}", n->token->string.hash & VARIABLE_TABLE_SIZE_MASK);
+    printf("{idx=%lu}", n->token->string.hash & VARIABLE_TABLE_SIZE_MASK);
     break;
   case N_ATOM:
   case N_BIN:

--- a/parser.c
+++ b/parser.c
@@ -192,6 +192,12 @@ eof:
   return stack[0]->children_length;
 }
 
+Node Parser_next(Parser *p) {
+  return (Node){
+      .type = N_UNKNOWN,
+  };
+}
+
 Str NODE_TYPE_MAP[] = {
     // strings, numbers, booleans
     [N_ATOM] = STRING("N_ATOM"),

--- a/parser.c
+++ b/parser.c
@@ -8,18 +8,18 @@
 #define NODE_CAP_GROW 2
 #define NODE_INITIAL_CHILD_SIZE 8
 
-Parser Parser_new(Allocator *alloc, Token **t) {
+Parser Parser_new(Allocator *alloc, Lexer *l) {
   return (Parser){
       .alloc = alloc,
-      .tokens = t,
+      .lexer = l,
       .pos = 0,
-      .cur = t[0],
+      .cur = Lexer_next(l),
   };
 }
 
 static void advance(Parser *p) {
   p->pos++;
-  p->cur = p->tokens[p->pos];
+  p->cur = Lexer_next(p->lexer);
 }
 
 static void consume(Parser *p, TokenType tt) {
@@ -39,7 +39,7 @@ static void consume(Parser *p, TokenType tt) {
 // added to n->children
 static void Node_add_child(Allocator *alloc, Node *n, Node *child) {
   if (n->children_length >= n->children_cap) {
-    size_t new = n->children_cap *NODE_CAP_GROW;
+    size_t new = n->children_cap * NODE_CAP_GROW;
     new = new < NODE_INITIAL_CHILD_SIZE ? NODE_INITIAL_CHILD_SIZE : new;
     Node **old = n->children;
     n->children = CALL(alloc, request, sizeof(Node *) * new);
@@ -52,6 +52,7 @@ static void Node_add_child(Allocator *alloc, Node *n, Node *child) {
   n->children[n->children_length++] = child;
 }
 
+// TODO: #5: restructure this to fit Parser_next
 size_t Parser_all(Node **nodes, Parser *p, size_t max_nodes) {
   // stack keeps the list(s) we are in, the last element is always the current
   // list, the first (0) is root

--- a/parser.c
+++ b/parser.c
@@ -227,15 +227,19 @@ Str NODE_TYPE_MAP[] = {
     [N_CALL] = STRING("N_CALL"),
     // error and end case
     [N_ROOT] = STRING("N_ROOT"),
-    [N_UNKNOWN] = STRING("N_UNKOWN"),
 };
 
 #if DEBUG
-void Node_debug(Node *n, size_t depth) {
+void Node_debug(const Node *n, size_t depth) {
+  ASSERT(n != NULL, "Node is NULL; THIS SHOULD NEVER HAPPEN");
   for (size_t i = 0; i < depth; i++) {
     putc(' ', stdout);
   }
-  Str_debug(&NODE_TYPE_MAP[n->type]);
+  if (n->type < 0) {
+    Str_debug(&STRING("N_UNKOWN"));
+  } else {
+    Str_debug(&NODE_TYPE_MAP[n->type]);
+  }
   switch (n->type) {
   case N_IDENT:
     Token_debug(n->token);

--- a/parser.c
+++ b/parser.c
@@ -241,7 +241,7 @@ void Node_debug(Node *n, size_t depth) {
   switch (n->type) {
   case N_IDENT:
     Token_debug(n->token);
-    printf("{hash=%zu}", n->token->string.hash & VARIABLE_TABLE_SIZE_MASK);
+    printf("{idx=%zu}", n->token->string.hash & VARIABLE_TABLE_SIZE_MASK);
     break;
   case N_ATOM:
   case N_BIN:

--- a/parser.h
+++ b/parser.h
@@ -27,7 +27,9 @@ typedef enum {
   N_BIN,
   // function call
   N_CALL,
-  // error and end case
+  // root node
+  N_ROOT,
+  // error case
   N_UNKNOWN,
 } NodeType;
 

--- a/parser.h
+++ b/parser.h
@@ -5,7 +5,7 @@
 
 typedef struct {
   Allocator *alloc;
-  Token **tokens;
+  Lexer *lexer;
   size_t pos;
   Token *cur;
 } Parser;
@@ -49,10 +49,9 @@ typedef struct __Node {
   struct __Node **children;
 } Node;
 
-Parser Parser_new(Allocator *alloc, Token **t);
-// Returns the next top level Node
+Parser Parser_new(Allocator *alloc, Lexer *l);
 Node Parser_next(Parser *p);
-size_t Parser_all(Node **nodes, Parser *p, size_t max_nodes);
+
 #if DEBUG
 void Node_debug(Node *n, size_t depth);
 #endif

--- a/parser.h
+++ b/parser.h
@@ -11,6 +11,8 @@ typedef struct {
 } Parser;
 
 typedef enum {
+  // error case
+  N_UNKNOWN = -1,
   // strings, numbers, booleans
   N_ATOM,
   // all identifiers
@@ -29,8 +31,6 @@ typedef enum {
   N_CALL,
   // root node
   N_ROOT,
-  // error case
-  N_UNKNOWN,
 } NodeType;
 
 extern Str NODE_TYPE_MAP[];
@@ -55,5 +55,5 @@ Parser Parser_new(Allocator *alloc, Lexer *l);
 Node Parser_next(Parser *p);
 
 #if DEBUG
-void Node_debug(Node *n, size_t depth);
+void Node_debug(const Node *n, size_t depth);
 #endif

--- a/pg.c
+++ b/pg.c
@@ -37,6 +37,8 @@ uint8_t pg_exec_file(Pg *pg, const char *filename) {
 
 void pg_destroy(Pg *pg) {
   Vm_destroy(&pg->__vm);
+  // Since the gc was disabled and the allocator thus wasnt destroyed by the vm,
+  // we will do it here.
   if (!pg->__conf->disable_gc) {
     CALL(pg->__alloc, destroy);
   }

--- a/pg.c
+++ b/pg.c
@@ -1,18 +1,14 @@
 #include "pg.h"
 #include "cc.h"
+#include "common.h"
 #include "io.h"
 #include "lexer.h"
 #include "mem.h"
 #include "parser.h"
 #include "vm.h"
 
-#define MIN_MEMORY 1 * 1024
-
 Pg pg_init(Vm_Config *conf) {
-  if (conf->max_memory < MIN_MEMORY) {
-    conf->max_memory = MIN_MEMORY;
-  }
-  Allocator *a = bump_init(conf->max_memory / 2);
+  Allocator *a = BumpResize_init(conf->max_memory);
   return (Pg){
       .__alloc = a,
       .__vm = Vm_new(*conf, a, NULL),
@@ -20,28 +16,23 @@ Pg pg_init(Vm_Config *conf) {
   };
 }
 
-// TODO: I have to make this better, maybe reattach lexer to the parser to not
-// use as much memory
-#define MAX_TOKENS 100000
-#define MAX_NODES 100000
-
-uint8_t pg_exec_file(Pg *pg, const char *filename) {
-  Str input = IO_read_file_to_string(filename);
-  Lexer l = Lexer_new(input);
-  Token **tokens = CALL(pg->__alloc, request, MAX_TOKENS * sizeof(Token *));
-  size_t count = Lexer_all(&l, pg->__alloc, tokens);
-  Parser p = Parser_new(pg->__alloc, tokens);
-  Node **nodes = CALL(pg->__alloc, request, MAX_NODES);
-  size_t node_count = Parser_all(nodes, &p, MAX_NODES);
-  Ctx ctx = cc(&pg->__vm, pg->__alloc, nodes, node_count);
+uint8_t pg_exec_Str(Pg *pg, Str input) {
+  Lexer lexer = Lexer_new(input);
+  Parser parser = Parser_new(pg->__alloc, &lexer);
+  Ctx ctx = cc(&pg->__vm, pg->__alloc, &parser);
 
   if (pg->__conf->disable_gc) {
-    pg->__vm.alloc = bump_init(pg->__conf->max_memory / 2);
+    pg->__vm.alloc = pg->__alloc;
   } else {
-    pg->__vm.alloc = xcgc_init(pg->__conf->max_memory / 2, &pg->__vm);
+    pg->__vm.alloc = xcgc_init(pg->__conf->max_memory, &pg->__vm);
   }
 
   return Vm_run(&pg->__vm);
+}
+
+uint8_t pg_exec_file(Pg *pg, const char *filename) {
+  Str input = IO_read_file_to_string(filename);
+  return pg_exec_Str(pg, input);
 }
 
 void pg_destroy(Pg *pg) {

--- a/pg.c
+++ b/pg.c
@@ -37,5 +37,7 @@ uint8_t pg_exec_file(Pg *pg, const char *filename) {
 
 void pg_destroy(Pg *pg) {
   Vm_destroy(&pg->__vm);
-  CALL(pg->__alloc, destroy);
+  if (!pg->__conf->disable_gc) {
+    CALL(pg->__alloc, destroy);
+  }
 }

--- a/pg.c
+++ b/pg.c
@@ -8,7 +8,7 @@
 #include "vm.h"
 
 Pg pg_init(Vm_Config *conf) {
-  Allocator *a = BumpResize_init(conf->max_memory);
+  Allocator *a = bump_init(MIN_MEM, conf->max_memory);
   return (Pg){
       .__alloc = a,
       .__vm = Vm_new(*conf, a, NULL),

--- a/pg.c
+++ b/pg.c
@@ -24,7 +24,7 @@ uint8_t pg_exec_Str(Pg *pg, Str input) {
   if (pg->__conf->disable_gc) {
     pg->__vm.alloc = pg->__alloc;
   } else {
-    pg->__vm.alloc = xcgc_init(pg->__conf->max_memory, &pg->__vm);
+    pg->__vm.alloc = xcgc_init(&pg->__vm, GC_MIN_HEAP, pg->__conf->max_memory);
   }
 
   return Vm_run(&pg->__vm);

--- a/pg.h
+++ b/pg.h
@@ -25,4 +25,5 @@ typedef void (*builtin_function)(Vm *vm);
 
 PG_API Pg pg_init(Vm_Config *conf);
 PG_API uint8_t pg_exec_file(Pg *pg, const char *filename);
+PG_API uint8_t pg_exec_Str(Pg *pg, Str input);
 PG_API void pg_destroy(Pg *pg);

--- a/strings.c
+++ b/strings.c
@@ -56,11 +56,11 @@ void Str_debug(const Str *str) {
   printf("%.*s", (int)str->len, str->p);
 }
 
-inline size_t Str_hash(const Str *str) {
+inline uint32_t Str_hash(const Str *str) {
   // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
   // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV_hash_parameters
-  size_t hash = FNV_OFFSET_BASIS;
-  for (size_t i = 0; i < str->len; i++) {
+  uint32_t hash = FNV_OFFSET_BASIS;
+  for (uint32_t i = 0; i < str->len; i++) {
     hash ^= str->p[i];
     hash *= FNV_PRIME;
   }

--- a/strings.c
+++ b/strings.c
@@ -56,11 +56,11 @@ void Str_debug(const Str *str) {
   printf("%.*s", (int)str->len, str->p);
 }
 
-inline uint32_t Str_hash(const Str *str) {
+inline uint64_t Str_hash(const Str *str) {
   // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV-1a_hash
   // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV_hash_parameters
-  uint32_t hash = FNV_OFFSET_BASIS;
-  for (uint32_t i = 0; i < str->len; i++) {
+  uint64_t hash = FNV_OFFSET_BASIS;
+  for (size_t i = 0; i < str->len; i++) {
     hash ^= str->p[i];
     hash *= FNV_PRIME;
   }

--- a/strings.c
+++ b/strings.c
@@ -51,8 +51,7 @@ bool Str_eq(const Str *a, const Str *b) {
 }
 
 void Str_debug(const Str *str) {
-  if (str == NULL)
-    return;
+  ASSERT(str != NULL, "HS");
   printf("%.*s", (int)str->len, str->p);
 }
 

--- a/strings.h
+++ b/strings.h
@@ -22,7 +22,6 @@ typedef struct __Str {
 
 #define FNV_OFFSET_BASIS 0x811c9dc5
 #define FNV_PRIME 0x01000193
-#define GLOBAL_MASK (GLOBAL_SIZE - 1)
 
 #define STRING(str) ((Str){.len = sizeof(str) - 1, .p = (const uint8_t *)str})
 #define STRING_EMPTY ((Str){.len = 0, .p = NULL})
@@ -33,6 +32,6 @@ Str Str_slice(const Str *str, size_t start, size_t end);
 Str Str_concat(const Str *a, const Str *b, Allocator *alloc);
 bool Str_eq(const Str *a, const Str *b);
 void Str_debug(const Str *str);
-size_t Str_hash(const Str *str);
+uint32_t Str_hash(const Str *str);
 int64_t Str_to_int64_t(const Str *str);
 double Str_to_double(const Str *str);

--- a/strings.h
+++ b/strings.h
@@ -20,8 +20,8 @@ typedef struct __Str {
   const uint8_t *p;
 } Str;
 
-#define FNV_OFFSET_BASIS 0x811c9dc5
-#define FNV_PRIME 0x01000193
+#define FNV_OFFSET_BASIS 0xcbf29ce484222325
+#define FNV_PRIME 0x00000100000001b3
 
 #define STRING(str) ((Str){.len = sizeof(str) - 1, .p = (const uint8_t *)str})
 #define STRING_EMPTY ((Str){.len = 0, .p = NULL})
@@ -32,6 +32,6 @@ Str Str_slice(const Str *str, size_t start, size_t end);
 Str Str_concat(const Str *a, const Str *b, Allocator *alloc);
 bool Str_eq(const Str *a, const Str *b);
 void Str_debug(const Str *str);
-uint32_t Str_hash(const Str *str);
+uint64_t Str_hash(const Str *str);
 int64_t Str_to_int64_t(const Str *str);
 double Str_to_double(const Str *str);

--- a/tests/test.c
+++ b/tests/test.c
@@ -145,7 +145,7 @@ int main() {
   size_t len = sizeof(cases) / sizeof(Case);
   for (size_t i = 0; i < len; i++) {
     Case c = cases[i];
-    Pg pg = pg_init(&(Vm_Config){});
+    Pg pg = pg_init(&(Vm_Config){.disable_gc = true});
     uint8_t code = pg_exec_Str(&pg, c.input);
 
     Vm *vm = &pg.__vm;
@@ -171,6 +171,7 @@ int main() {
       passed++;
       printf("[+][PASS][Case %zu/%zu] in=`%s` \n", i + 1, len, c.input.p);
     }
+
     pg_destroy(&pg);
   }
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -15,7 +15,7 @@ typedef struct {
 
 #define CASE(in, r0)                                                           \
   {                                                                            \
-      .input = STRING(#in "\0"),                                               \
+      .input = STRING(#in),                                                    \
       .expected_r0 = r0,                                                       \
   }
 
@@ -58,22 +58,23 @@ bool Value_cmp_deep(const Value *a, const Value *b) {
 
 // @_ is used to simply return its argument since pg doesnt allow top level
 // atoms
-void builtin_(Vm *vm) { RETURN(ARG(0)); }
+void builtin_test_return(Vm *vm) { RETURN(ARG(0)); }
 
 int main() {
   Case cases[] = {
     // atoms:
 
     // doubles
-    CASE((@_ 3.1415), VAL(.type = V_DOUBLE, .floating = 3.1415)),
-    CASE((@_ 0.1415), VAL(.type = V_DOUBLE, .floating = 0.1415)),
+    CASE((@test_return 3.1415), VAL(.type = V_DOUBLE, .floating = 3.1415)),
+    CASE((@test_return 0.1415), VAL(.type = V_DOUBLE, .floating = 0.1415)),
 
-    CASE((@_ "string"), VAL(.type = V_STR, .string = STRING("string"))),
+    CASE((@test_return "string"),
+         VAL(.type = V_STR, .string = STRING("string"))),
     {
-        .input = ((Str){.len = sizeof("(@_ 'quoted)"
+        .input = ((Str){.len = sizeof("(@test_return 'quoted)"
                                       "\0") -
                                1,
-                        .p = (const uint8_t *)"(@_ 'quoted)"
+                        .p = (const uint8_t *)"(@test_return 'quoted)"
                                               "\0"}),
         .expected_r0 =
             (Value){.type = V_STR,
@@ -83,10 +84,11 @@ int main() {
     // TODO: this is for future me to implement
     // CASE("escaped string\"", BC(OP_LOAD, 0), VAL(.type = V_STRING, .string
     // = STRING("escaped string\""))),
-    CASE((@_ false), VAL(.type = V_FALSE)),
+    CASE((@test_return false), VAL(.type = V_FALSE)),
     // checking if boolean interning works
-    CASE((@_ true)(@_ false)(@_ false), VAL(.type = V_FALSE)),
-    CASE((@_ "hello"), VAL(.type = V_STR, .string = STRING("hello"))),
+    CASE((@test_return true)(@test_return false)(@test_return false),
+         VAL(.type = V_FALSE)),
+    CASE((@test_return "hello"), VAL(.type = V_STR, .string = STRING("hello"))),
 
     // too large integer and double values
     // https://github.com/xNaCly/purple-garden/issues/1
@@ -129,9 +131,9 @@ int main() {
     CASE((= false false), VAL(.type = V_TRUE)),
 
     // variables
-    CASE((@let name "user")(@_ name),
+    CASE((@let name "user")(@test_return name),
          VAL(.type = V_STR, .string = STRING("user"))),
-    CASE((@let age 25)(@_ age), VAL(.type = V_INT, .integer = 25)),
+    CASE((@let age 25)(@test_return age), VAL(.type = V_INT, .integer = 25)),
 
     // functions
     CASE((@fn ret[arg] arg)(ret 25), VAL(.type = V_INT, .integer = 25)),
@@ -156,8 +158,9 @@ int main() {
   size_t len = sizeof(cases) / sizeof(Case);
   for (size_t i = 0; i < len; i++) {
     Case c = cases[i];
-    Pg pg = pg_init(&(Vm_Config){.disable_gc = true});
-    PG_REGISTER_BUILTIN(&pg, "_", builtin_);
+    Vm_Config conf = (Vm_Config){.disable_gc = true};
+    Pg pg = pg_init(&conf);
+    PG_REGISTER_BUILTIN(&pg, "test_return", builtin_test_return);
     uint8_t code = pg_exec_Str(&pg, c.input);
 
     Vm *vm = &pg.__vm;

--- a/vm.c
+++ b/vm.c
@@ -108,7 +108,7 @@ int Vm_run(Vm *vm) {
     VM_OP op = vm->bytecode[vm->pc];
     uint32_t arg = vm->bytecode[vm->pc + 1];
 
-#define PRINT_REGISTERS 0
+#define PRINT_REGISTERS 2
 #if DEBUG
     vm->instruction_counter[op]++;
     Str *str = &OP_MAP[op];

--- a/vm.c
+++ b/vm.c
@@ -130,12 +130,18 @@ int Vm_run(Vm *vm) {
       vm->size_hint = arg;
       break;
     case OP_NEW: {
-      NEW({});
       Value v = (Value){};
       switch ((VM_New)arg) {
       case VM_NEW_ARRAY:
         v.type = V_ARRAY;
-        v.array = List_new(vm->size_hint, vm->alloc);
+        if (vm->size_hint != 0) {
+          v.array = List_new(vm->size_hint, vm->alloc);
+        } else {
+          v.array = (List){
+              .cap = 0,
+              .len = 0,
+          };
+        }
         break;
       default:
         ASSERT(0, "OP_NEW unimplemented");

--- a/vm.c
+++ b/vm.c
@@ -108,7 +108,7 @@ int Vm_run(Vm *vm) {
     VM_OP op = vm->bytecode[vm->pc];
     uint32_t arg = vm->bytecode[vm->pc + 1];
 
-#define PRINT_REGISTERS 5
+#define PRINT_REGISTERS 0
 #if DEBUG
     vm->instruction_counter[op]++;
     Str *str = &OP_MAP[op];

--- a/vm.h
+++ b/vm.h
@@ -31,7 +31,7 @@ typedef enum {
 
 // PERF: maybe _ is too many, but prefetching a recursion depth can have
 // some positive effects on the runtime performance
-#define PREALLOCATE_FREELIST_SIZE 5
+#define PREALLOCATE_FREELIST_SIZE 0
 
 // A frame represents a Scope, a new scope is created upon entering a function -
 // since functions are pure, there is no way to interact with the previous frame

--- a/vm.h
+++ b/vm.h
@@ -31,7 +31,7 @@ typedef enum {
 
 // PERF: maybe _ is too many, but prefetching a recursion depth can have
 // some positive effects on the runtime performance
-#define PREALLOCATE_FREELIST_SIZE 32
+#define PREALLOCATE_FREELIST_SIZE 0
 
 // A frame represents a Scope, a new scope is created upon entering a function -
 // since functions are pure, there is no way to interact with the previous frame

--- a/vm.h
+++ b/vm.h
@@ -31,7 +31,7 @@ typedef enum {
 
 // PERF: maybe _ is too many, but prefetching a recursion depth can have
 // some positive effects on the runtime performance
-#define PREALLOCATE_FREELIST_SIZE 0
+#define PREALLOCATE_FREELIST_SIZE 5
 
 // A frame represents a Scope, a new scope is created upon entering a function -
 // since functions are pure, there is no way to interact with the previous frame
@@ -45,7 +45,7 @@ typedef struct Frame {
   // function
   size_t return_to_bytecode;
   // stores Values by their hash, serving as a variable table
-  Value variable_table[VARIABLE_TABLE_SIZE];
+  List variable_table;
 } Frame;
 
 typedef struct __Vm {

--- a/xcgc.c
+++ b/xcgc.c
@@ -33,8 +33,8 @@ void *gc_request(void *ctx, size_t size) {
 
   if (c->pos + size >= c->size) {
 #if VERBOSE_ALLOCATOR
-    printf("[XCGC] triggering gc at %zu, %.3f%% of %zuB\n", c->pos,
-           (c->pos * 100) / (double)c->size, c->size);
+    printf("[XCGC] triggering gc at %zu, %.3f%% of %zuB because of %zuB\n",
+           c->pos, (c->pos * 100) / (double)c->size, c->size, size);
 #endif
     xcgc_run(c);
 

--- a/xcgc.c
+++ b/xcgc.c
@@ -25,6 +25,12 @@ static void xcgc_run(GcCtx *c) {
 
 void *gc_request(void *ctx, size_t size) {
   GcCtx *c = (GcCtx *)ctx;
+
+  // the request is now failable because we want to stay under MAX_MEM
+  if (c->pos + size >= MAX_MEM) {
+    return NULL;
+  }
+
   if (c->pos + size >= c->size) {
 #if VERBOSE_ALLOCATOR
     printf("[XCGC] triggering gc at %zu, %.3f%% of %zuB\n", c->pos,

--- a/xcgc.c
+++ b/xcgc.c
@@ -32,7 +32,7 @@ void *gc_request(void *ctx, size_t size) {
   }
 
   if (c->pos + size >= c->size) {
-#if VERBOSE_ALLOCATOR
+#ifdef VERBOSE_ALLOCATOR
     printf("[XCGC] triggering gc at %zu, %.3f%% of %zuB because of %zuB\n",
            c->pos, (c->pos * 100) / (double)c->size, c->size, size);
 #endif
@@ -47,7 +47,7 @@ void *gc_request(void *ctx, size_t size) {
   void *p = (char *)c->to_space + c->pos;
   c->pos += size;
 
-#if VERBOSE_ALLOCATOR
+#ifdef VERBOSE_ALLOCATOR
   double avail = c->size - c->pos;
   printf(
       "[XCGC] allocated %zuB, %.0fB::%.3f%% available until gc is triggered\n",


### PR DESCRIPTION
## Idea

This is necessary because currently a hello world is like 140MB and thats laughable shitty, the new strat is a combination of a resizable bump allocator for the compilation pipeline and a copy from space to space garbage collector like in the first lisp implementations. This is the first commit of that attempt. In optimal think a hello world would use around 400B in pg, since:

```scheme
(@println "Hello World")
```

1. The input is mmaped => we dont care
2. Tokens () and EOF are interned => 3 Tokens = 32*3B=96B (`@`, `println` and `"Hello World"`
3. 3 Nodes: Root->Builtin->Atom => 40B*2, since Root is stack allocated 
4. Str "Hello World" is a wrapper for a reference into the mmaped input of size 24B
5. The str has to be wrapped by a Value in the runtime: 40B
6. The bytecode has to be kept somewhere: Around 80B

Meaning: somewhere between 216B and 400B, which is like 0.00001% of the current usage. Thus the goal of this attempt is to move the real runtime memory usage towards that optimal position without completly destroying runtime performance due to many heavy reallocations

## First results


| Stage | pipeline usage | pipeline allocation | vm usage | vm allocation |
| - | - | - | - | - |
| old | 69632.34 KB | 149504.00 KB | 40.08 KB | 1024.00 KB |
| new | 9.30 KB | 44.00 KB | 1 KB | 50 KB |
|  |  |  |  |  |
| Δ | −69623.04 KB | −149460 KB | −39.08 KB | −974 KB |
| % | −99.99% | −99.97% | −97.51% | −95.12% |
| × factor | ~7,486× less | ~3,398× less | ~40× less | ~20× less |


## Old debug:

```text
(@println "Hello" "World")
[ALLOCATOR] main.c@main::183: pipeline_allocator->request(file_size_or_min * sizeof(Token *))
[ALLOCATOR] lexer.c@Lexer_all::182: a->request(sizeof(Token))
[ALLOCATOR] lexer.c@Lexer_all::317: a->request(sizeof(Token))
[ALLOCATOR] lexer.c@Lexer_all::317: a->request(sizeof(Token))
[T_DELIMITOR_LEFT]
[T_BUILTIN][println]
[T_STRING][Hello]
[T_STRING][World]
[T_DELIMITOR_RIGHT]
[T_EOF]
[ALLOCATOR] main.c@main::194: pipeline_allocator->stats()
lex : 32768.09KB of 149504.00KB used (21.92%)
[ALLOCATOR] main.c@main::201: pipeline_allocator->request(node_count)
[ALLOCATOR] parser.c@Parser_all::109: p->alloc->request(sizeof(Node))
[ALLOCATOR] parser.c@Parser_all::91: p->alloc->request(sizeof(Node))
[ALLOCATOR] parser.c@Node_add_child::45: alloc->request(sizeof(Node *) * new)
[ALLOCATOR] parser.c@Parser_all::91: p->alloc->request(sizeof(Node))
N_BUILTIN[T_BUILTIN][println](
 N_ATOM[T_STRING][Hello],
 N_ATOM[T_STRING][World]
)
[ALLOCATOR] main.c@main::212: pipeline_allocator->stats()
ast : 40960.27KB of 149504.00KB used (27.40%)
[ALLOCATOR] vm.c@Vm_new::35: static_alloc->request(sizeof(uint32_t) * BYTECODE_SIZE)
[ALLOCATOR] vm.c@Vm_new::36: static_alloc->request((sizeof(Value *) * GLOBAL_SIZE))
[ALLOCATOR] cc.c@cc::420: alloc->request(sizeof(size_t) * GLOBAL_SIZE)
[ALLOCATOR] cc.c@token_to_value::24: a->request(sizeof(Value))
allocating r1
[ALLOCATOR] cc.c@token_to_value::24: a->request(sizeof(Value))
allocating r2
freeing r2
freeing r1
__globals:
        False; {idx=0}
        True; {idx=1}
        Option/None; {idx=2}
        Str(`Hello`); {idx=3,hash=274763}
        Str(`World`); {idx=4,hash=60723}

__entry:
        LOADG 3; Str(`Hello`)
        STORE 1
        LOADG 4; Str(`World`)
        STORE 2
        ARGS 256 ; count=2,offset=0
        BUILTIN 166
[ALLOCATOR] main.c@main::234: pipeline_allocator->stats()
cc  : 69632.34KB of 149504.00KB used (46.575567%)
[ALLOCATOR] vm.c@freelist_preallocate::64: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 8208B, 1040368B::99.217% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::64: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 8208B, 1032160B::98.434% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::64: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 8208B, 1023952B::97.652% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::64: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 8208B, 1015744B::96.869% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::64: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 8208B, 1007536B::96.086% available until gc is triggered
[VM][000000|00001] LOADG     =000003{ Option/None Option/None Option/None Option/None Option/None }
[VM][000002|00003] STORE     =000001{ Str(`Hello`) Option/None Option/None Option/None Option/None }
[VM][000004|00005] LOADG     =000004{ Str(`Hello`) Str(`Hello`) Option/None Option/None Option/None }
[VM][000006|00007] STORE     =000002{ Str(`World`) Str(`Hello`) Option/None Option/None Option/None }
[VM][000008|00009] ARGS      =000256{ Str(`World`) Str(`Hello`) Str(`World`) Option/None Option/None }
[VM][000010|00011] BUILTIN   =000166{ Str(`World`) Str(`Hello`) Str(`World`) Option/None Option/None }
Hello World
[ALLOCATOR] main.c@main::252: vm.alloc->stats()
vm  : 40.08KB of 1024.00KB used (3.913879%)
| Opcode     | Compiled %               | Executed %               |
| ---------- | ------------------------ | ------------------------ |
| STORE      | 2               (33.33%) | 2               (33.33%) |
| LOADG      | 2               (33.33%) | 2               (33.33%) |
| ARGS       | 1               (16.67%) | 1               (16.67%) |
| BUILTIN    | 1               (16.67%) | 1               (16.67%) |
| ========== | ======================== | ======================== |
| ::<>       | 6               (99.99%) | 6               (99.99%) |
[ALLOCATOR] main.c@main::262: pipeline_allocator->destroy()
[ALLOCATOR] vm.c@Vm_destroy::324: vm->alloc->destroy()
```

## New debug:

```text
[ALLOCATOR] vm.c@Vm_new::35: static_alloc->request((sizeof(Value *) * GLOBAL_SIZE))
[ALLOCATOR] main.c@main::183: pipeline_allocator->stats()
vmnew: 4.00KB of 44.00KB used (9.090909%)
[ALLOCATOR] bcb.c@ByteCodeBuilder_new::11: a->request(cap * sizeof(uint32_t))
[ALLOCATOR] cc.c@cc::422: alloc->request(sizeof(size_t) * GLOBAL_SIZE)
[ALLOCATOR] parser.c@Parser_next::118: p->alloc->request(sizeof(Node))
[T_DELIMITOR_LEFT]
[ALLOCATOR] lexer.c@Lexer_next::178: a->request(sizeof(Token))
[T_BUILTIN][println]
[ALLOCATOR] lexer.c@Lexer_next::304: a->request(sizeof(Token))
[ALLOCATOR] parser.c@Parser_next::100: p->alloc->request(sizeof(Node))
[T_STRING][Hello World]
[ALLOCATOR] parser.c@Node_add_child::49: alloc->request(sizeof(Node *) * new)
[T_DELIMITOR_RIGHT]
[ALLOCATOR] parser.c@Node_add_child::49: alloc->request(sizeof(Node *) * new)
N_BUILTIN[T_BUILTIN][println](
 N_ATOM[T_STRING][Hello World]
)
[ALLOCATOR] cc.c@token_to_value::24: a->request(sizeof(Value))
allocating r1
freeing r1
__globals:
        False; {idx=0}
        True; {idx=1}
        Option/None; {idx=2}
        Str(`Hello World`); {idx=3,hash=295}

__entry:
        LOADG 3; Str(`Hello World`)
        STORE 1
        ARGS 128 ; count=1,offset=0
        BUILTIN 166
[ALLOCATOR] main.c@main::201: pipeline_allocator->stats()
cc  : 9.30KB of 44.00KB used (21.129261%)
[ALLOCATOR] vm.c@freelist_preallocate::63: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 32B, 51168B::99.938% available until gc is triggered
[ALLOCATOR] adts.c@List_new::14: a->request(l.cap * sizeof(Value))
[XCGC] allocated 256B, 50912B::99.438% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::63: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 32B, 50880B::99.375% available until gc is triggered
[ALLOCATOR] adts.c@List_new::14: a->request(l.cap * sizeof(Value))
[XCGC] allocated 256B, 50624B::98.875% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::63: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 32B, 50592B::98.812% available until gc is triggered
[ALLOCATOR] adts.c@List_new::14: a->request(l.cap * sizeof(Value))
[XCGC] allocated 256B, 50336B::98.312% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::63: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 32B, 50304B::98.250% available until gc is triggered
[ALLOCATOR] adts.c@List_new::14: a->request(l.cap * sizeof(Value))
[XCGC] allocated 256B, 50048B::97.750% available until gc is triggered
[ALLOCATOR] vm.c@freelist_preallocate::63: fl->alloc->request(sizeof(Frame))
[XCGC] allocated 32B, 50016B::97.688% available until gc is triggered
[ALLOCATOR] adts.c@List_new::14: a->request(l.cap * sizeof(Value))
[XCGC] allocated 256B, 49760B::97.188% available until gc is triggered
[VM][000000|00001] LOADG     =000003{ Option/None Option/None Option/None Option/None Option/None }
[VM][000002|00003] STORE     =000001{ Str(`Hello World`) Option/None Option/None Option/None Option/None }
[VM][000004|00005] ARGS      =000128{ Str(`Hello World`) Str(`Hello World`) Option/None Option/None Option/None }
[VM][000006|00007] BUILTIN   =000166{ Str(`Hello World`) Str(`Hello World`) Option/None Option/None Option/None }
Hello World
[ALLOCATOR] main.c@main::219: vm.alloc->stats()
vm  : 1.41KB of 50.00KB used (2.812500%)
| Opcode     | Compiled %               | Executed %               |
| ---------- | ------------------------ | ------------------------ |
| STORE      | 1               (25.00%) | 1               (25.00%) |
| ARGS       | 1               (25.00%) | 1               (25.00%) |
| BUILTIN    | 1               (25.00%) | 1               (25.00%) |
| LOADG      | 1               (25.00%) | 1               (25.00%) |
| ========== | ======================== | ======================== |
| ::<>       | 4               (99.99%) | 4               (99.99%) |
[ALLOCATOR] main.c@main::229: pipeline_allocator->destroy()
[ALLOCATOR] vm.c@Vm_destroy::327: vm->alloc->destroy()
```

