### PR TITLE
Extend std lib to allow for returning anomalies

### DIFF
--- a/src/bc/mod.rs
+++ b/src/bc/mod.rs
@@ -90,7 +90,9 @@ impl<'cc> Cc<'cc> {
         // usage and extensible enough for extreme niche usecases requiring more than 64 alive
         // values at the same time
 
-        self.regalloc = Ralloc::new(&fun.live_set);
+        let live_set = fun.live_set();
+        crate::trace!("Computed live_set for {}: {:?}", fun.name, live_set);
+        self.regalloc = Ralloc::new(&live_set);
         crate::trace!(
             "[bc] Computed ralloc map for `{}`: {:#?}",
             fun.name,
@@ -110,7 +112,7 @@ impl<'cc> Cc<'cc> {
             self.block_map.insert(block.id, self.buf.len() as u16);
 
             for (i, instruction) in block.instructions.iter().enumerate() {
-                self.instr(fun, i as u32, instruction);
+                self.instr(fun, &live_set, i as u32, instruction);
             }
 
             self.term(fun, block.term.as_ref());
@@ -142,7 +144,7 @@ impl<'cc> Cc<'cc> {
     }
 
     fn restore_call_args(&mut self, r_to_spil: &[u8]) {
-        for dst in r_to_spil.into_iter().rev() {
+        for dst in r_to_spil.iter().rev() {
             self.emit(Op::Pop { dst: *dst });
         }
     }
@@ -218,7 +220,13 @@ impl<'cc> Cc<'cc> {
         }
     }
 
-    fn instr(&mut self, fun: &Func<'cc>, pos: u32, i: &ir::Instr<'cc>) {
+    fn instr(
+        &mut self,
+        fun: &Func<'cc>,
+        live_set: &HashMap<u32, (u32, u32)>,
+        pos: u32,
+        i: &ir::Instr<'cc>,
+    ) {
         match i {
             ir::Instr::Cast {
                 dst: TypeId { id, ty },
@@ -256,7 +264,7 @@ impl<'cc> Cc<'cc> {
                 let pc = func.pc;
 
                 let mut alive_after_call_spill = vec![];
-                for (v, (def, last_use)) in &fun.live_set {
+                for (v, (def, last_use)) in live_set {
                     // the value is defined before the call and used after the call, thus must be
                     // spilled
                     if def < &pos && &pos < last_use {
@@ -267,7 +275,7 @@ impl<'cc> Cc<'cc> {
                             def,
                             last_use
                         );
-                        let Some(regalloc::Location::Reg(src)) = self.regalloc.map.get(&v) else {
+                        let Some(regalloc::Location::Reg(src)) = self.regalloc.map.get(v) else {
                             unreachable!();
                         };
 

--- a/src/bc/regalloc.rs
+++ b/src/bc/regalloc.rs
@@ -135,7 +135,7 @@ mod regalloc_test {
     fn spilling_when_registers_exhausted() {
         let mut live_set = std::collections::HashMap::new();
 
-        let reg_count = crate::vm::REGISTER_COUNT as usize;
+        let reg_count = crate::vm::REGISTER_COUNT;
 
         // Create more intervals than registers
         for i in 0..reg_count + 2 {

--- a/src/err.rs
+++ b/src/err.rs
@@ -6,8 +6,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct PgError {
-    pub title: &'static str,
-    pub msg: Option<String>,
+    pub msg: String,
     pub line: usize,
     pub start: usize,
     pub len: usize,
@@ -16,8 +15,7 @@ pub struct PgError {
 impl From<&Token<'_>> for PgError {
     fn from(value: &Token) -> Self {
         PgError {
-            title: "temp",
-            msg: None,
+            msg: String::new(),
             line: value.line,
             start: value.col,
             len: value.t.as_str().len(),
@@ -43,8 +41,7 @@ impl From<Anomaly> for PgError {
             _ => "Virtual Machine Anomaly",
         };
         PgError {
-            title,
-            msg: Some(value.as_str().to_string()),
+            msg: value.as_str().to_string(),
             line: 0,
             start: 0,
             len: 0,
@@ -53,34 +50,19 @@ impl From<Anomaly> for PgError {
 }
 
 impl PgError {
-    pub fn render(self, lines: &[&str]) {
-        println!("-> err: {}", self.title);
-        println!("   {}\n", self.msg.unwrap_or_default());
-
-        let prev = self.line.saturating_sub(1);
-        if let Some(prev_line) = lines.get(prev)
-            && prev != self.line
-        {
-            println!("{:03} | {prev_line}", prev + 1);
-        }
+    // TODO: introduce a writer to write errors to?
+    pub fn render(self, file: &str, lines: &[&str]) {
+        println!("{file}:{}:{}: {}", self.line, self.start, self.msg);
 
         if let Some(line) = lines.get(self.line) {
-            println!("{:03} | {line}", self.line + 1);
-            println!("{}~ here", " ".repeat(self.start + 7))
-        }
-
-        let next = self.line + 1;
-        if let Some(next_line) = lines.get(next)
-            && next != self.line
-        {
-            println!("{:03} | {next_line}", next + 1);
+            println!("{line}");
+            println!("{}~", " ".repeat(self.start))
         }
     }
 
-    pub fn with_msg(title: &'static str, msg: impl Into<String>, from: impl Into<PgError>) -> Self {
+    pub fn with_msg(msg: impl Into<String>, from: impl Into<PgError>) -> Self {
         let mut conv = from.into();
-        conv.msg = Some(msg.into());
-        conv.title = title;
+        conv.msg = msg.into();
         conv
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -38,8 +38,12 @@ impl From<Anomaly> for PgError {
     fn from(value: Anomaly) -> Self {
         // TODO: do some prep in anomaly for finding out which ast node resulted in what bytecode
         // ranges
+        let title = match value {
+            Anomaly::Msg { msg, .. } => msg,
+            _ => "Virtual Machine Anomaly",
+        };
         PgError {
-            title: "Virtual Machine Anomaly",
+            title,
             msg: Some(value.as_str().to_string()),
             line: 0,
             start: 0,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,80 @@
+use crate::mmap;
+use std::fs::File;
+use std::os::fd::AsRawFd;
+
+/// Dealing with different input sources efficiently and in a unified way, by for instance memory
+/// mapping file inputs on x86 linux
+pub enum Input {
+    Str(String),
+    File(Vec<u8>),
+    MmapedFile {
+        /// this needs to be kept so its not dropped while reading
+        file: File,
+        len: usize,
+        ptr: std::ptr::NonNull<u8>,
+    },
+}
+
+impl Input {
+    pub fn from_file(file_name: &str) -> Self {
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        {
+            let file = File::open(file_name).expect("Failed to open file");
+            let meta = file.metadata().expect("Failed to get metadata");
+            let len = meta.len() as usize;
+            let ptr = mmap::mmap(
+                None,
+                len,
+                mmap::MmapProt::READ,
+                mmap::MmapFlags::PRIVATE,
+                file.as_raw_fd(),
+                0,
+            )
+            .expect("Failed to memory map file");
+            crate::trace!("mmaped the file");
+            Self::MmapedFile { file, len, ptr }
+        }
+
+        #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+        {
+            let mut file = File::open(file_name).expect("Failed to open file");
+            let meta = file.metadata().expect("Failed to get metadata");
+            let len = meta.len() as usize;
+            let mut buf = Vec::with_capacity(len);
+            std::io::Read::read_to_end(&mut file, &mut buf).expect("Failed to read file");
+            Self::File(buf)
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Input::Str(s) => s.as_bytes(),
+            Input::File(buf) => &buf,
+            Input::MmapedFile { file, len, ptr } => unsafe {
+                std::slice::from_raw_parts(ptr.as_ptr(), *len)
+            },
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Input::Str(s) => &s,
+            Input::File(buf) => str::from_utf8(&buf).unwrap(),
+            Input::MmapedFile { file, len, ptr } => unsafe {
+                str::from_utf8(std::slice::from_raw_parts(ptr.as_ptr(), *len)).unwrap()
+            },
+        }
+    }
+}
+
+impl Drop for Input {
+    fn drop(&mut self) {
+        match self {
+            Input::MmapedFile { file, len, ptr } => {
+                let cpy = *ptr;
+                mmap::munmap(cpy, *len).expect("Failed to unmap file");
+            }
+            _ => (),
+        }
+    }
+}

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -85,13 +85,15 @@ impl<'lower> Lower<'lower> {
                     Type::D(doub) => Const::Double(
                         doub.parse::<f64>()
                             .map_err(|e: num::ParseFloatError| {
-                                PgError::with_msg("Number parsing failure", e.to_string(), raw)
+                                PgError::with_msg(e.to_string(), raw)
                             })?
                             .to_bits(),
                     ),
-                    Type::I(int) => Const::Int(int.parse().map_err(|e: num::ParseIntError| {
-                        PgError::with_msg("Number parsing failure", e.to_string(), raw)
-                    })?),
+                    Type::I(int) => {
+                        Const::Int(int.parse().map_err(|e: num::ParseIntError| {
+                            PgError::with_msg(e.to_string(), raw)
+                        })?)
+                    }
                     Type::True => Const::True,
                     Type::False => Const::False,
                     _ => unreachable!(),
@@ -116,7 +118,6 @@ impl<'lower> Lower<'lower> {
                     Some(*id)
                 } else {
                     return Err(PgError::with_msg(
-                        "Undefined binding",
                         format!("Undefined variable `{}`", i),
                         name,
                     ));
@@ -182,7 +183,6 @@ impl<'lower> Lower<'lower> {
                     self.ctx.env.insert(i, id);
                 } else {
                     return Err(PgError::with_msg(
-                        "Empty binding value",
                         "RHS of let has to return a value, but it didnt",
                         name,
                     ));
@@ -322,7 +322,6 @@ impl<'lower> Lower<'lower> {
                         let Some((target_id, ret)) = self.func_name_to_id.get(inner_name).cloned()
                         else {
                             return Err(PgError::with_msg(
-                                "Undefined function",
                                 format!("Undefined function `{inner_name}`"),
                                 name,
                             ));

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -215,7 +215,6 @@ impl<'lower> Lower<'lower> {
                 self.func_name_to_id.insert(ident_name, (id, ret.clone()));
                 let func = Func {
                     name: ident_name,
-                    live_set: HashMap::new(),
                     id,
                     params: args
                         .iter()
@@ -461,84 +460,6 @@ impl<'lower> Lower<'lower> {
         })
     }
 
-    pub fn determine_live_set(func: &mut Func<'_>) {
-        let mut def = HashMap::new();
-        let mut last_use = HashMap::new();
-
-        let mut idx = 0;
-        for param in &func.params {
-            def.insert(param.0, idx);
-            last_use.entry(param.0).or_insert(idx);
-        }
-
-        for block in &func.blocks {
-            for instr in &block.instructions {
-                match instr {
-                    Instr::Bin { dst, lhs, rhs, .. } => {
-                        last_use.insert(lhs.0, idx);
-                        last_use.insert(rhs.0, idx);
-
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    Instr::LoadConst { dst, .. } => {
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    Instr::Call { dst, args, .. }
-                    | Instr::Sys { dst, args, .. }
-                    | Instr::Tail { dst, args, .. } => {
-                        for arg in args {
-                            last_use.insert(arg.0, idx);
-                        }
-
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    Instr::Cast { dst, from } => {
-                        last_use.insert(from.0, idx);
-
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    _ => unreachable!(),
-                }
-
-                idx += 1;
-            }
-
-            if let Some(term) = &block.term {
-                match term {
-                    Terminator::Return(Some(Id(id))) => {
-                        last_use.insert(*id, idx);
-                    }
-                    Terminator::Jump { params, .. } => {
-                        for id in params {
-                            last_use.insert(id.0, idx);
-                        }
-                    }
-                    Terminator::Branch { cond, yes, no } => {
-                        last_use.insert(cond.0, idx);
-
-                        for id in &yes.1 {
-                            last_use.insert(id.0, idx);
-                        }
-
-                        for id in &no.1 {
-                            last_use.insert(id.0, idx);
-                        }
-                    }
-                    _ => (),
-                }
-            }
-        }
-
-        for (v, d) in def {
-            let l = last_use.get(&v).copied().unwrap_or(d);
-            func.live_set.insert(v, (d, l));
-        }
-    }
-
     /// Lower [ast] into a list of Func nodes, the entry point is always `entry`
     pub fn ir_from(mut self, ast: &[Node<'lower>]) -> Result<Vec<Func<'lower>>, PgError> {
         let mut typechecker = typecheck::Typechecker::new();
@@ -554,7 +475,6 @@ impl<'lower> Lower<'lower> {
             ret: None,
             blocks: vec![],
             params: vec![],
-            live_set: HashMap::new(),
         };
         let entry = self.new_block();
         self.switch_to_block(entry);
@@ -566,11 +486,6 @@ impl<'lower> Lower<'lower> {
         }
 
         self.functions.push(self.ctx.func);
-
-        for func in self.functions.iter_mut() {
-            Self::determine_live_set(func);
-            crate::trace!("Computed live_set for {}: {:?}", func.name, func.live_set);
-        }
 
         Ok(self.functions)
     }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -133,10 +133,92 @@ pub struct Block<'b> {
 pub struct Func<'f> {
     pub name: &'f str,
     pub id: Id,
-    /// mapping any vN to (def, last_use), used for spill detection for preserving registers around
-    /// call boundaries, since all registers in pg are callersaved (def(v) lteq C lt last_use(v)).
-    pub live_set: HashMap<u32, (u32, u32)>,
     pub params: Vec<Id>,
     pub ret: Option<Type>,
     pub blocks: Vec<Block<'f>>,
+}
+
+impl Func<'_> {
+    /// mapping any vN to (def, last_use), used for spill detection for preserving registers around
+    /// call boundaries, since all registers in pg are callersaved (def(v) lteq C lt last_use(v)).
+    pub fn live_set(&self) -> HashMap<u32, (u32, u32)> {
+        let mut def = HashMap::new();
+        let mut last_use = HashMap::new();
+        let mut live_set = HashMap::new();
+
+        let mut idx = 0;
+        for param in &self.params {
+            def.insert(param.0, idx);
+            last_use.entry(param.0).or_insert(idx);
+        }
+
+        for block in &self.blocks {
+            for instr in &block.instructions {
+                match instr {
+                    Instr::Bin { dst, lhs, rhs, .. } => {
+                        last_use.insert(lhs.0, idx);
+                        last_use.insert(rhs.0, idx);
+
+                        def.insert(dst.id.0, idx);
+                        last_use.entry(dst.id.0).or_insert(idx);
+                    }
+                    Instr::LoadConst { dst, .. } => {
+                        def.insert(dst.id.0, idx);
+                        last_use.entry(dst.id.0).or_insert(idx);
+                    }
+                    Instr::Call { dst, args, .. }
+                    | Instr::Sys { dst, args, .. }
+                    | Instr::Tail { dst, args, .. } => {
+                        for arg in args {
+                            last_use.insert(arg.0, idx);
+                        }
+
+                        def.insert(dst.id.0, idx);
+                        last_use.entry(dst.id.0).or_insert(idx);
+                    }
+                    Instr::Cast { dst, from } => {
+                        last_use.insert(from.0, idx);
+
+                        def.insert(dst.id.0, idx);
+                        last_use.entry(dst.id.0).or_insert(idx);
+                    }
+                    _ => unreachable!(),
+                }
+
+                idx += 1;
+            }
+
+            if let Some(term) = &block.term {
+                match term {
+                    Terminator::Return(Some(Id(id))) => {
+                        last_use.insert(*id, idx);
+                    }
+                    Terminator::Jump { params, .. } => {
+                        for id in params {
+                            last_use.insert(id.0, idx);
+                        }
+                    }
+                    Terminator::Branch { cond, yes, no } => {
+                        last_use.insert(cond.0, idx);
+
+                        for id in &yes.1 {
+                            last_use.insert(id.0, idx);
+                        }
+
+                        for id in &no.1 {
+                            last_use.insert(id.0, idx);
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        for (v, d) in def {
+            let l = last_use.get(&v).copied().unwrap_or(d);
+            live_set.insert(v, (d, l));
+        }
+
+        live_set
+    }
 }

--- a/src/ir/typecheck.rs
+++ b/src/ir/typecheck.rs
@@ -65,7 +65,6 @@ impl<'t> Typechecker<'t> {
                     (Type::Double, Type::Double) => Type::Double,
                     (_, _) if lhs == rhs => {
                         return Err(PgError::with_msg(
-                            "Type error",
                             format!(
                                 "Unsupported type {} for {:?}, want Int or Double",
                                 lhs,
@@ -76,7 +75,6 @@ impl<'t> Typechecker<'t> {
                     }
                     (_, _) => {
                         return Err(PgError::with_msg(
-                            "Type error",
                             format!(
                                 "Incompatible types {} and {} for {:?}",
                                 lhs,
@@ -94,7 +92,6 @@ impl<'t> Typechecker<'t> {
                     (Type::Int, Type::Int) => {}
                     (_, _) if lhs == rhs => {
                         return Err(PgError::with_msg(
-                            "Type error",
                             format!(
                                 "Unsupported type {} for {:?}, want Int or Double",
                                 lhs,
@@ -105,7 +102,6 @@ impl<'t> Typechecker<'t> {
                     }
                     (_, _) => {
                         return Err(PgError::with_msg(
-                            "Type error",
                             format!(
                                 "Incompatible types {} and {} for {:?}, want Int",
                                 lhs,
@@ -125,7 +121,6 @@ impl<'t> Typechecker<'t> {
                     (Type::Int, Type::Int) => {}
                     (_, _) if lhs == rhs => {
                         return Err(PgError::with_msg(
-                            "Type error",
                             format!(
                                 "Unsupported type {} for {:?}, want Int or Double for both sides",
                                 lhs,
@@ -136,7 +131,6 @@ impl<'t> Typechecker<'t> {
                     }
                     (_, _) => {
                         return Err(PgError::with_msg(
-                            "Type error",
                             format!(
                                 "Incompatible types {} and {} for {:?}",
                                 lhs,
@@ -163,7 +157,6 @@ impl<'t> Typechecker<'t> {
             (Type::Int, Type::Bool) => Type::Bool,
             (_, _) => {
                 return Err(PgError::with_msg(
-                    "Cast type error",
                     format!("Can not cast {} to {}", i, o),
                     at,
                 ));
@@ -200,11 +193,7 @@ impl<'t> Typechecker<'t> {
                 };
 
                 let t = self.env.get(inner_name).ok_or_else(|| {
-                    PgError::with_msg(
-                        "Undefined Binding",
-                        format!("binding `{inner_name}` not found"),
-                        name,
-                    )
+                    PgError::with_msg(format!("binding `{inner_name}` not found"), name)
                 })?;
 
                 self.map.insert(*id, t.clone());
@@ -250,7 +239,6 @@ impl<'t> Typechecker<'t> {
 
                 if self.functions.contains_key(inner_name) {
                     return Err(PgError::with_msg(
-                        "Function already defined",
                         format!("`{}` is already defined", inner_name),
                         name,
                     ));
@@ -285,7 +273,6 @@ impl<'t> Typechecker<'t> {
                 let computed_ret = self.block_type(body)?;
                 if ret != computed_ret {
                     return Err(PgError::with_msg(
-                        "Function return type mismatch",
                         format!(
                             "`{}` annotated with return type {}, but returns {}",
                             inner_name, ret, computed_ret
@@ -330,7 +317,6 @@ impl<'t> Typechecker<'t> {
 
                         let Some(pkg) = self.packages.get(pkg_name) else {
                             return Err(PgError::with_msg(
-                                "Undefined package",
                                 format!("Can't find package `{}`", pkg_name),
                                 name,
                             ));
@@ -338,7 +324,6 @@ impl<'t> Typechecker<'t> {
 
                         let Some(fun) = pkg.get(inner_name).cloned() else {
                             return Err(PgError::with_msg(
-                                "Undefined function",
                                 format!("Call to undefined function `{}.{}`", pkg_name, inner_name),
                                 name,
                             ));
@@ -355,7 +340,6 @@ impl<'t> Typechecker<'t> {
                         };
                         let Some(fun) = self.functions.get(inner_name).cloned() else {
                             return Err(PgError::with_msg(
-                                "Undefined function",
                                 format!("Call to undefined function `{}`", inner_name),
                                 name,
                             ));
@@ -367,7 +351,6 @@ impl<'t> Typechecker<'t> {
 
                 if args.len() != fun.args.len() {
                     return Err(PgError::with_msg(
-                        "Function argument count mismatch",
                         format!(
                             "`{}` requires {} arguments, got {}",
                             inner_name,
@@ -386,7 +369,6 @@ impl<'t> Typechecker<'t> {
 
                     if expected_type != &provided_type {
                         return Err(PgError::with_msg(
-                            "Function argument type mismatch",
                             format!(
                                 "`{}` arg{} expected type {}, got {} instead",
                                 inner_name, i, expected_type, provided_type,
@@ -415,7 +397,6 @@ impl<'t> Typechecker<'t> {
 
                     if condition_type != Type::Bool {
                         return Err(PgError::with_msg(
-                            "Non bool match condition",
                             format!(
                                 "Match conditions must be Bool, got {} instead",
                                 condition_type
@@ -437,7 +418,6 @@ impl<'t> Typechecker<'t> {
 
                     if ty != &first_type {
                         return Err(PgError::with_msg(
-                            "Incompatible match case return type",
                             format!(
                                 "Match cases must resolve to the same type, but got {} and {}",
                                 first_type, ty
@@ -453,7 +433,6 @@ impl<'t> Typechecker<'t> {
             Node::Import { id, pkgs, src } => {
                 if pkgs.is_empty() {
                     return Err(PgError::with_msg(
-                        "Empty import statement",
                         "Import without any paths to import is considered invalid",
                         src,
                     ));
@@ -466,7 +445,6 @@ impl<'t> Typechecker<'t> {
 
                     let Some(pkg) = pstd::resolve_pkg(pkg_name) else {
                         return Err(PgError::with_msg(
-                            "Unresolvable pkg import",
                             format!("Wasnt able to find a package named `{pkg_name}`"),
                             pkg_tok,
                         ));

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -33,8 +33,7 @@ impl<'l> Lexer<'l> {
 
     fn make_err(&self, msg: impl Into<String>, start: usize) -> PgError {
         PgError {
-            title: "Lexer error",
-            msg: Some(msg.into()),
+            msg: msg.into(),
             line: self.line,
             start,
             len: self.col - start,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod err;
 pub mod gc;
 pub mod help;
+pub mod input;
 pub mod ir;
 pub mod jit;
 pub mod lex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod help;
 pub mod ir;
 pub mod jit;
 pub mod lex;
+pub mod mmap;
 pub mod opt;
 pub mod parser;
 pub mod std;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
             );
             println!("{}", BUILD_INFO.replace(";", "\n"));
             let exe = std::env::current_exe().unwrap();
-            println!("from: {}", exe.display());
+            println!("from={}", exe.display());
             std::process::exit(0);
         }
         _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,11 +103,15 @@ fn main() {
         }
     }
 
-    let input = match args.run {
-        Some(ref i) => Input::Str(i.clone()),
+    let (input, input_source) = match args.run {
+        Some(ref i) => (Input::Str(i.clone()), "stdio"),
         None => {
-            let file_name = args.target.as_ref().expect("No file or `-r` specified");
-            Input::from_file(file_name)
+            let file_name = args
+                .target
+                .as_ref()
+                .expect("No file or `-r` specified")
+                .as_str();
+            (Input::from_file(file_name), file_name)
         }
     };
 
@@ -116,7 +120,7 @@ fn main() {
         Ok(a) => a,
         Err(e) => {
             let lines = input.as_str().lines().collect::<Vec<&str>>();
-            e.render(&lines);
+            e.render(input_source, &lines);
             std::process::exit(1);
         }
     };
@@ -138,7 +142,7 @@ fn main() {
         Ok(ir) => ir,
         Err(e) => {
             let lines = input.as_str().lines().collect::<Vec<&str>>();
-            e.render(&lines);
+            e.render(input_source, &lines);
             std::process::exit(1);
         }
     };
@@ -158,7 +162,7 @@ fn main() {
     let mut cc = bc::Cc::new();
     if let Err(e) = cc.compile(&ir) {
         let lines = input.as_str().lines().collect::<Vec<&str>>();
-        e.render(&lines);
+        e.render(input_source, &lines);
         std::process::exit(1);
     };
 
@@ -191,7 +195,7 @@ fn main() {
 
     if let Err(e) = vm.run() {
         let lines = input.as_str().lines().collect::<Vec<&str>>();
-        Into::<PgError>::into(e).render(&lines);
+        Into::<PgError>::into(e).render(input_source, &lines);
 
         if args.backtrace {
             let entry_point_pc = function_table

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
 use purple_garden::{
     bc, config,
     err::PgError,
-    help, ir,
+    help,
+    input::Input,
+    ir,
     lex::Lexer,
-    mmap, opt,
+    opt,
     parser::Parser,
     std::{self as pstd, Pkg},
     trace,
 };
-use std::{collections::HashMap, fs::File, os::fd::AsRawFd};
+use std::collections::HashMap;
 
 pub const BUILD_INFO: &str = concat!(
     "version=",
@@ -101,49 +103,19 @@ fn main() {
         }
     }
 
-    // TODO: replace this with an "owning" type
-    let input: &[u8] = match args.run {
-        Some(ref i) => i.as_bytes(),
+    let input = match args.run {
+        Some(ref i) => Input::Str(i.clone()),
         None => {
             let file_name = args.target.as_ref().expect("No file or `-r` specified");
-
-            #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
-            {
-                let file = File::open(file_name).expect("Failed to open file");
-                let meta = file.metadata().expect("Failed to get metadata");
-                let len = meta.len() as usize;
-                let ptr = mmap::mmap(
-                    None,
-                    len,
-                    mmap::MmapProt::READ,
-                    mmap::MmapFlags::PRIVATE,
-                    file.as_raw_fd(),
-                    0,
-                )
-                .expect("Failed to memory map file");
-                unsafe { std::slice::from_raw_parts(ptr.as_ptr(), len) }
-            }
-
-            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-            {
-                let mut file = File::open(file_name).expect("Failed to open file");
-                let meta = file.metadata().expect("Failed to get metadata");
-                let len = meta.len() as usize;
-                let mut buf = Vec::with_capacity(len);
-                std::io::Read::read_to_end(&mut file, &mut buf).expect("Failed to read file");
-                &buf
-            }
+            Input::from_file(file_name)
         }
     };
 
-    let lexer = Lexer::new(&input);
+    let lexer = Lexer::new(input.as_bytes());
     let ast = match Parser::new(lexer).and_then(|n| n.parse()) {
         Ok(a) => a,
         Err(e) => {
-            let lines = str::from_utf8(&input)
-                .unwrap()
-                .lines()
-                .collect::<Vec<&str>>();
+            let lines = input.as_str().lines().collect::<Vec<&str>>();
             e.render(&lines);
             std::process::exit(1);
         }
@@ -165,10 +137,7 @@ fn main() {
     let mut ir = match lower.ir_from(&ast) {
         Ok(ir) => ir,
         Err(e) => {
-            let lines = str::from_utf8(&input)
-                .unwrap()
-                .lines()
-                .collect::<Vec<&str>>();
+            let lines = input.as_str().lines().collect::<Vec<&str>>();
             e.render(&lines);
             std::process::exit(1);
         }
@@ -188,10 +157,7 @@ fn main() {
 
     let mut cc = bc::Cc::new();
     if let Err(e) = cc.compile(&ir) {
-        let lines = str::from_utf8(&input)
-            .unwrap()
-            .lines()
-            .collect::<Vec<&str>>();
+        let lines = input.as_str().lines().collect::<Vec<&str>>();
         e.render(&lines);
         std::process::exit(1);
     };
@@ -224,10 +190,7 @@ fn main() {
     }
 
     if let Err(e) = vm.run() {
-        let lines = str::from_utf8(&input)
-            .unwrap()
-            .lines()
-            .collect::<Vec<&str>>();
+        let lines = input.as_str().lines().collect::<Vec<&str>>();
         Into::<PgError>::into(e).render(&lines);
 
         if args.backtrace {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,12 @@ use purple_garden::{
     err::PgError,
     help, ir,
     lex::Lexer,
-    opt,
+    mmap, opt,
     parser::Parser,
     std::{self as pstd, Pkg},
     trace,
 };
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs::File, os::fd::AsRawFd};
 
 pub const BUILD_INFO: &str = concat!(
     "version=",
@@ -100,12 +100,40 @@ fn main() {
             }
         }
     }
-    let input = match args.run {
-        Some(ref i) => i.as_bytes().to_vec(),
-        // PERF: mmap this
-        None => fs::read(args.target.clone().expect("No file or `-r` specified"))
-            .expect("Failed to read from file")
-            .to_vec(),
+
+    // TODO: replace this with an "owning" type
+    let input: &[u8] = match args.run {
+        Some(ref i) => i.as_bytes(),
+        None => {
+            let file_name = args.target.as_ref().expect("No file or `-r` specified");
+
+            #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+            {
+                let file = File::open(file_name).expect("Failed to open file");
+                let meta = file.metadata().expect("Failed to get metadata");
+                let len = meta.len() as usize;
+                let ptr = mmap::mmap(
+                    None,
+                    len,
+                    mmap::MmapProt::READ,
+                    mmap::MmapFlags::PRIVATE,
+                    file.as_raw_fd(),
+                    0,
+                )
+                .expect("Failed to memory map file");
+                unsafe { std::slice::from_raw_parts(ptr.as_ptr(), len) }
+            }
+
+            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            {
+                let mut file = File::open(file_name).expect("Failed to open file");
+                let meta = file.metadata().expect("Failed to get metadata");
+                let len = meta.len() as usize;
+                let mut buf = Vec::with_capacity(len);
+                std::io::Read::read_to_end(&mut file, &mut buf).expect("Failed to read file");
+                &buf
+            }
+        }
     };
 
     let lexer = Lexer::new(&input);

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -1,0 +1,127 @@
+//! copied and applied from https://github.com/xnacly/stinkarm/blob/master/src/mem/mmap.rs
+
+const MMAP_SYSCALL: i64 = 9;
+const MPROTECT_SYSCALL: i64 = 10;
+const MUNMAP_SYSCALL: i64 = 11;
+
+// Not an enum, since NONE, READ, WRITE and EXEC arent mutually exclusive
+pub struct MmapProt(i32);
+impl MmapProt {
+    /// no permissions
+    pub const NONE: MmapProt = MmapProt(0x00);
+    /// pages can be read
+    pub const READ: MmapProt = MmapProt(0x01);
+    /// pages can be written
+    pub const WRITE: MmapProt = MmapProt(0x02);
+    /// pages can be executed
+    pub const EXEC: MmapProt = MmapProt(0x04);
+    pub fn bits(self) -> i32 {
+        self.0
+    }
+}
+
+impl std::ops::BitOr for MmapProt {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        MmapProt(self.0 | rhs.0)
+    }
+}
+
+pub struct MmapFlags(i32);
+
+impl MmapFlags {
+    /// share changes
+    pub const SHARED: MmapFlags = MmapFlags(0x0001);
+    /// changes are private
+    pub const PRIVATE: MmapFlags = MmapFlags(0x0002);
+    /// map addr must be exactly as requested
+    pub const FIXED: MmapFlags = MmapFlags(0x0010);
+
+    // MAP_FIXED_NOREPLACE (Linux ≥ 5.4)
+    pub const NOREPLACE: MmapFlags = MmapFlags(0x100000);
+
+    /// allocated from memory, swap space
+    pub const ANONYMOUS: MmapFlags = MmapFlags(0x20);
+
+    /// mapping is used for stack
+    pub const STACK: MmapFlags = MmapFlags(0x4000);
+
+    /// omit from dumps
+    pub const CONCEAL: MmapFlags = MmapFlags(0x8000);
+
+    pub fn bits(self) -> i32 {
+        self.0
+    }
+}
+
+impl std::ops::BitOr for MmapFlags {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        MmapFlags(self.0 | rhs.0)
+    }
+}
+
+#[inline(always)]
+pub fn mmap(
+    ptr: Option<std::ptr::NonNull<u8>>,
+    length: usize,
+    prot: MmapProt,
+    flags: MmapFlags,
+    fd: i32,
+    offset: i64,
+) -> Result<std::ptr::NonNull<u8>, String> {
+    let ret: isize;
+
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") MMAP_SYSCALL,
+            in("rdi") ptr.map(|nn| nn.as_ptr()).unwrap_or(std::ptr::null_mut()),
+            in("rsi") length,
+            in("rdx") prot.bits(),
+            in("r10") flags.bits(),
+            in("r8")  fd,
+            in("r9")  offset,
+            lateout("rax") ret,
+            clobber_abi("sysv64"),
+            options(nostack)
+        );
+    }
+    if ret < 0 {
+        let errno = -ret;
+        return Err(format!(
+            "mmap failed (errno {}): {}",
+            errno,
+            std::io::Error::from_raw_os_error(errno as i32)
+        ));
+    }
+
+    Ok(unsafe { std::ptr::NonNull::new_unchecked(ret as *mut u8) })
+}
+
+#[inline(always)]
+pub fn munmap(ptr: std::ptr::NonNull<u8>, size: usize) -> Result<(), String> {
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") MUNMAP_SYSCALL,
+            in("rdi") ptr.as_ptr(),
+            in("rsi") size,
+            lateout("rax") ret,
+            clobber_abi("sysv64"),
+            options(nostack)
+        );
+    }
+
+    if ret < 0 {
+        let errno = -ret;
+        return Err(format!(
+            "munmap failed (errno {}): {}",
+            errno,
+            std::io::Error::from_raw_os_error(errno as i32)
+        ));
+    }
+
+    Ok(())
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,6 @@ impl<'p> Parser<'p> {
             self.advance()?;
         } else {
             return Err(PgError::with_msg(
-                "Unexpected Token",
                 format!(
                     "Expected `{:?}`, got {}({:?})",
                     ty,
@@ -60,7 +59,6 @@ impl<'p> Parser<'p> {
             Ok(matched)
         } else {
             Err(PgError::with_msg(
-                "Unexpected Token",
                 format!("Expected an identifier, got {:?}", self.cur.t),
                 &self.cur,
             ))
@@ -119,7 +117,6 @@ impl<'p> Parser<'p> {
         while !self.at_end() && self.cur().t != Type::BraceRight {
             let &Token { t: Type::S(_), .. } = self.cur() else {
                 return Err(PgError::with_msg(
-                    "Malformed import",
                     "Only strings are allowed as import paths",
                     &self.cur,
                 ));
@@ -213,7 +210,6 @@ impl<'p> Parser<'p> {
 
         let Some(default) = default else {
             return Err(PgError::with_msg(
-                "Missing match default branch",
                 "A match statement requires a default branch",
                 &tok,
             ));
@@ -385,7 +381,6 @@ impl<'p> Parser<'p> {
             }
             _ => {
                 return Err(PgError::with_msg(
-                    "Unexpected Malformed Type",
                     "Bad type, expected either type, ?type, [type] or type[type], where type is str, int, double, bool or void",
                     self.cur(),
                 ));

--- a/src/std/conv.rs
+++ b/src/std/conv.rs
@@ -1,13 +1,13 @@
 use crate::vm::{Anomaly, Value, Vm};
 
-pub fn from_int(vm: &mut Vm) -> Value {
+pub fn from_int(vm: &mut Vm) -> Result<Value, Anomaly> {
     let arg0 = vm.r(0).as_int();
     let as_string = arg0.to_string();
-    Value::from(vm.new_string(as_string))
+    Ok(Value::from(vm.new_string(as_string)))
 }
 
-pub fn from_double(vm: &mut Vm) -> Value {
+pub fn from_double(vm: &mut Vm) -> Result<Value, Anomaly> {
     let arg0 = vm.r(0).as_f64();
     let as_string = arg0.to_string();
-    Value::from(vm.new_string(as_string))
+    Ok(Value::from(vm.new_string(as_string)))
 }

--- a/src/std/io.rs
+++ b/src/std/io.rs
@@ -1,11 +1,11 @@
 use crate::vm::{Anomaly, Value, Vm};
 
-pub fn println(vm: &mut Vm) -> Value {
+pub fn println(vm: &mut Vm) -> Result<Value, Anomaly> {
     println!("{}", vm.r(0).as_str(&vm.strings));
-    Value(0)
+    Ok(Value(0))
 }
 
-pub fn print(vm: &mut Vm) -> Value {
+pub fn print(vm: &mut Vm) -> Result<Value, Anomaly> {
     print!("{}", vm.r(0).as_str(&vm.strings));
-    Value(0)
+    Ok(Value(0))
 }

--- a/src/std/strings.rs
+++ b/src/std/strings.rs
@@ -1,18 +1,18 @@
 use crate::vm::{Anomaly, Value, Vm};
 
-pub fn repeat(vm: &mut Vm) -> Value {
+pub fn repeat(vm: &mut Vm) -> Result<Value, Anomaly> {
     let arg0 = vm.r(0).as_str(&vm.strings);
     let arg1 = vm.r(1).as_int();
     let repeated = arg0.repeat(arg1 as usize);
-    Value::from(vm.new_string(repeated))
+    Ok(Value::from(vm.new_string(repeated)))
 }
 
-pub fn contains(vm: &mut Vm) -> Value {
+pub fn contains(vm: &mut Vm) -> Result<Value, Anomaly> {
     let arg0 = vm.r(0).as_str(&vm.strings);
     let arg1 = vm.r(1).as_str(&vm.strings);
-    Value::from(arg0.contains(arg1))
+    Ok(Value::from(arg0.contains(arg1)))
 }
 
-pub fn len(vm: &mut Vm) -> Value {
-    Value::from(vm.r(0).as_str(&vm.strings).len())
+pub fn len(vm: &mut Vm) -> Result<Value, Anomaly> {
+    Ok(Value::from(vm.r(0).as_str(&vm.strings).len()))
 }

--- a/src/std/testing.rs
+++ b/src/std/testing.rs
@@ -1,9 +1,12 @@
 use crate::vm::{Anomaly, Value, Vm};
 
-pub fn assert(vm: &mut Vm) -> Value {
+pub fn assert(vm: &mut Vm) -> Result<Value, Anomaly> {
     if !vm.r(0).as_bool() {
-        // TODO: replace this with some kind of error as a value? No idea
-        panic!("test.assert: assertion failed")
+        Err(Anomaly::Msg {
+            msg: "test.assert: assertion failed",
+            pc: vm.pc,
+        })
+    } else {
+        Ok(Value(0))
     }
-    Value(0)
 }

--- a/src/vm/anomaly.rs
+++ b/src/vm/anomaly.rs
@@ -4,6 +4,7 @@ pub enum Anomaly {
     DivisionByZero { pc: usize },
     Unimplemented { pc: usize },
     InvalidSyscall { pc: usize },
+    Msg { msg: &'static str, pc: usize },
 }
 
 impl Anomaly {
@@ -12,6 +13,7 @@ impl Anomaly {
             Anomaly::DivisionByZero { .. } => "Division by zero",
             Anomaly::Unimplemented { .. } => "Unimplemented",
             Anomaly::InvalidSyscall { .. } => "InvalidSyscall",
+            Anomaly::Msg { msg, .. } => msg,
         }
     }
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -10,7 +10,7 @@ pub use crate::vm::anomaly::Anomaly;
 pub use crate::vm::value::Value;
 use op::Op;
 
-pub type BuiltinFn = fn(&mut Vm) -> Value;
+pub type BuiltinFn = fn(&mut Vm) -> Result<Value, Anomaly>;
 pub fn syscall_unimplemented<'vm>(vm: &mut Vm<'vm>) -> Result<Value, Anomaly> {
     Err(Anomaly::InvalidSyscall { pc: vm.pc })
 }
@@ -224,7 +224,7 @@ impl<'vm> Vm<'vm> {
                     continue;
                 }
                 Op::Sys { idx } => unsafe {
-                    r_mut!(0) = (*syscalls.add(idx as usize))(self);
+                    r_mut!(0) = (*syscalls.add(idx as usize))(self)?;
                 },
                 Op::Ret => {
                     if self.config.backtrace {


### PR DESCRIPTION
- [x] builtinfn returns a result of value and anomaly
- [x] rework err display to 
```text
<file>:<line>:<col>: <msg>
<line>
<padding>^
```

Comparing to the current inline:

```text
err: test.assert: assertion failed
   test.assert: assertion failed

001 | import "testing"
       ~ here
002 | testing.assert(25 == 12)
```

```text
/home/teo/programming/purple-garden/test.garden:2:9: assertion failed
testing.assert(25 == 12)
        ^
```