### PR TITLE
Type::Foreign(str) for opaque rust pointers

### DIFF
--- a/help/embed.txt
+++ b/help/embed.txt
@@ -1,0 +1,124 @@
+Purple garden was created to be fast, but also to be embeddable and to be used
+in embedding contexts like scripting for game engines, http servers and the
+likes. 
+
+
+Lets consider a simple counter, we will make it thread safe via AtomicI64:
+
+
+    use crate::vm::{Anomaly, Value, Vm};
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    pub struct Counter {
+        value: AtomicI64,
+    }
+
+    impl Counter {
+        pub fn new() -> Self {
+            Self {
+                value: AtomicI64::new(0),
+            }
+        }
+
+        pub fn inc(&self) -> i64 {
+            self.value.fetch_add(1, Ordering::SeqCst) + 1
+        }
+
+        pub fn get(&self) -> i64 {
+            self.value.load(Ordering::SeqCst)
+        }
+    }
+
+The next step is to create wrappers for Counter::{new, inc, get}:
+
+
+    pub fn new(vm: &mut Vm) -> Result<Value, Anomaly> {
+        let counter = Box::new(Counter::new());
+        Ok(Value::from_ptr(Box::into_raw(counter)))
+    }
+
+    pub fn increment(vm: &mut Vm) -> Result<Value, Anomaly> {
+        let ptr = vm.r(0).as_ptr::<Counter>();
+
+        if ptr.is_null() {
+            return Err(Anomaly::Msg {
+                msg: "counter.increment: null pointer",
+                pc: vm.pc,
+            });
+        }
+
+        let counter = unsafe { &*ptr };
+
+        let val = counter.inc();
+        Ok(Value::from(val))
+    }
+
+    pub fn get(vm: &mut Vm) -> Result<Value, Anomaly> {
+        let ptr = vm.r(0).as_ptr::<Counter>();
+
+        if ptr.is_null() {
+            return Err(Anomaly::Msg {
+                msg: "counter.get: null pointer",
+                pc: vm.pc,
+            });
+        }
+
+        let counter = unsafe { &*ptr };
+        Ok(Value::from(counter.get()))
+    }
+
+This counter now needs these methods registered in the vm as the "counter"
+package:
+
+// TODO: add the macro for doing this easier once its done
+
+    Pkg {
+        name: "counter",
+        doc: "heap-backed counter objects",
+        pkgs: &[],
+        fns: &[
+            Fn {
+                name: "new",
+                doc: "creates a new counter",
+                ptr: crate::std::counter::new,
+                args: &[],
+                ret: Type::Foreign("counter"),
+            },
+            Fn {
+                name: "increment",
+                doc: "increments counter and returns value",
+                ptr: crate::std::counter::increment,
+                args: &[Type::Foreign("counter")],
+                ret: Type::Void,
+            },
+            Fn {
+                name: "get",
+                doc: "returns current counter value",
+                ptr: crate::std::counter::get,
+                args: &[Type::Foreign("counter")],
+                ret: Type::Int,
+            },
+        ],
+    },
+
+The 'Type::Foreign("counter")' is used to distinguish different foreign
+interactions in the typechecker, thus making things like the following
+impossible:
+
+
+    # counter1 is a copy of the counter package registered before, just the
+    # Foreign str id is counter1, instead of counter
+    import ("counter" "counter1" "testing")
+
+    let c = counter.new()
+    counter.increment(c)
+    counter.increment(c)
+    counter.increment(c)
+    counter1.increment(c)
+    testing.assert(counter.get(c) == 3)
+
+This fails at typechecking:
+
+    test.garden:6:18: `counter1.increment` arg0 expected Foreign<counter1>, got Foreign<counter> instead:
+    counter1.increment(c)
+                      ~

--- a/help/embed.txt
+++ b/help/embed.txt
@@ -2,7 +2,6 @@ Purple garden was created to be fast, but also to be embeddable and to be used
 in embedding contexts like scripting for game engines, http servers and the
 likes. 
 
-
 Lets consider a simple counter, we will make it thread safe via AtomicI64:
 
 
@@ -101,10 +100,19 @@ package:
         ],
     },
 
+These registered functions can now be used in the purple garden language:
+
+    import ("counter" "testing")
+
+    let c = counter.new()
+    counter.increment(c)
+    counter.increment(c)
+    counter.increment(c)
+    testing.assert(counter.get(c) == 3)
+
 The 'Type::Foreign("counter")' is used to distinguish different foreign
 interactions in the typechecker, thus making things like the following
 impossible:
-
 
     # counter1 is a copy of the counter package registered before, just the
     # Foreign str id is counter1, instead of counter

--- a/help/types.txt
+++ b/help/types.txt
@@ -6,10 +6,9 @@ Purple garden provides the primitive types any programmer would expect:
     Double
     Str
 
-Furthermore, there are three non primitive types:
+Furthermore, there are four non primitive types:
 
     Option
     Array
     Struct
-
-// TODO:
+    Foreign

--- a/src/err.rs
+++ b/src/err.rs
@@ -52,7 +52,7 @@ impl From<Anomaly> for PgError {
 impl PgError {
     // TODO: introduce a writer to write errors to?
     pub fn render(self, file: &str, lines: &[&str]) {
-        println!("{file}:{}:{}: {}", self.line, self.start, self.msg);
+        println!("{file}:{}:{}: {}:", self.line, self.start, self.msg);
 
         if let Some(line) = lines.get(self.line) {
             println!("{line}");

--- a/src/help.rs
+++ b/src/help.rs
@@ -2,6 +2,7 @@ pub fn print_help_by_topic(topic: Option<&str>) -> &str {
     if let Some(topic) = topic {
         match topic {
             "types" => include_str!("../help/types.txt"),
+            "embed" => include_str!("../help/embed.txt"),
             _ => "unknown topic",
         }
     } else {

--- a/src/ir/ptype.rs
+++ b/src/ir/ptype.rs
@@ -13,6 +13,13 @@ pub enum Type {
     Str,
     Option(Box<Type>),
     Array(Box<Type>),
+    // Foreign type for handling opaque rust data feed into the vm runtime
+    //
+    // which is useful for something like Foreign("counter") vs
+    // Foreign("player") in the typesystem, meaning functions defined on the former can not be
+    // called on the latter, resulting in a type error
+    Foreign(&'static str),
+    // TODO: add Record type for structuring data together as fields
 }
 
 impl Type {
@@ -35,6 +42,7 @@ impl Display for Type {
             Type::Int => write!(f, "Int"),
             Type::Double => write!(f, "Double"),
             Type::Str => write!(f, "Str"),
+            Type::Foreign(id) => write!(f, "Foreign<{id}>"),
             Type::Option(inner) => write!(f, "Option<{}>", inner),
             Type::Array(inner) => write!(f, "Array<{}>", inner),
         }

--- a/src/ir/typecheck.rs
+++ b/src/ir/typecheck.rs
@@ -328,7 +328,10 @@ impl<'t> Typechecker<'t> {
                                 name,
                             ));
                         };
-                        (name, inner_name, fun)
+                        let mut s = String::from(*pkg_name);
+                        s.push('.');
+                        s.push_str(*inner_name);
+                        (name, s, fun)
                     }
                     Node::Ident { name, .. } => {
                         let lex::Token {
@@ -344,7 +347,7 @@ impl<'t> Typechecker<'t> {
                                 name,
                             ));
                         };
-                        (name, inner_name, fun)
+                        (name, inner_name.to_string(), fun)
                     }
                     _ => unreachable!(),
                 };
@@ -370,7 +373,7 @@ impl<'t> Typechecker<'t> {
                     if expected_type != &provided_type {
                         return Err(PgError::with_msg(
                             format!(
-                                "`{}` arg{} expected type {}, got {} instead",
+                                "`{}` arg{} expected {}, got {} instead",
                                 inner_name, i, expected_type, provided_type,
                             ),
                             tok,

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -64,8 +64,7 @@ impl<'c> From<Const<'c>> for Value {
             Const::True => 1u64,
             Const::Int(i) => i as u64,
             Const::Double(bits) => bits,
-            // my favorite placeholder
-            _ => return Value(0xDEADAFFE),
+            _ => unimplemented!("0xDEADAFFE"),
         })
     }
 }


### PR DESCRIPTION
Add support for things like:

```python
import ("counter" "testing")

let c = counter.new()
counter.increment(c)
counter.increment(c)
counter.increment(c)
testing.assert(counter.get(c) == 3)
```

Via 

```rust
// ==> src/std/counter.rs <==
use crate::vm::{Anomaly, Value, Vm};
use std::sync::atomic::{AtomicI64, Ordering};

pub struct Counter {
    value: AtomicI64,
}

impl Counter {
    pub fn new() -> Self {
        Self {
            value: AtomicI64::new(0),
        }
    }

    pub fn inc(&self) -> i64 {
        self.value.fetch_add(1, Ordering::SeqCst) + 1
    }

    pub fn get(&self) -> i64 {
        self.value.load(Ordering::SeqCst)
    }
}

pub fn new(vm: &mut Vm) -> Result<Value, Anomaly> {
    let counter = Box::new(Counter::new());
    Ok(Value::from_ptr(Box::into_raw(counter)))
}

pub fn increment(vm: &mut Vm) -> Result<Value, Anomaly> {
    let ptr = vm.r(0).as_ptr::<Counter>();

    if ptr.is_null() {
        return Err(Anomaly::Msg {
            msg: "counter.increment: null pointer",
            pc: vm.pc,
        });
    }

    let counter = unsafe { &*ptr };

    let val = counter.inc();
    Ok(Value::from(val))
}

pub fn get(vm: &mut Vm) -> Result<Value, Anomaly> {
    let ptr = vm.r(0).as_ptr::<Counter>();

    if ptr.is_null() {
        return Err(Anomaly::Msg {
            msg: "counter.get: null pointer",
            pc: vm.pc,
        });
    }

    let counter = unsafe { &*ptr };
    Ok(Value::from(counter.get()))
}

// ==> src/std/mod.rs <==

// ...
pub static STD: &[Pkg] = &[
// ...
    Pkg {
        name: "counter",
        doc: "heap-backed counter objects",
        pkgs: &[],
        fns: &[
            Fn {
                name: "new",
                doc: "creates a new counter",
                ptr: crate::std::counter::new,
                args: &[],
                ret: Type::Foreign("counter"),
            },
            Fn {
                name: "increment",
                doc: "increments counter and returns value",
                ptr: crate::std::counter::increment,
                args: &[Type::Foreign("counter")],
                ret: Type::Void,
            },
            Fn {
                name: "get",
                doc: "returns current counter value",
                ptr: crate::std::counter::get,
                args: &[Type::Foreign("counter")],
                ret: Type::Int,
            },
        ],
    },
];
```

Also added typechecking level support for making sure two foreign interactions are of the same context:

```txt
test.garden:6:18: `counter1.increment` arg0 expected Foreign<counter1>, got Foreign<counter> instead:
counter1.increment(c)
                  ~
```