### PR TITLE
Register allocation fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "purple-garden"
 version = "0.1.0"
 description = "Lean scripting language, designed and implemented with a focus on performance and a low memory profile "
 edition = "2024"
+default-run = "purple-garden"
 
 [features]
 trace = []

--- a/src/bc/mod.rs
+++ b/src/bc/mod.rs
@@ -103,7 +103,7 @@ impl<'cc> Cc<'cc> {
         // values at the same time
 
         let live_set = fun.live_set();
-        self.regalloc = Ralloc::new(&live_set);
+        self.regalloc = Ralloc::new(live_set.clone());
         crate::trace!(
             "[bc::Cc::cc][{}] regalloc map: {:#?}",
             fun.name,
@@ -230,7 +230,7 @@ impl<'cc> Cc<'cc> {
     fn instr(
         &mut self,
         fun: &Func<'cc>,
-        live_set: &HashMap<u32, (u32, u32)>,
+        live_set: &HashMap<Id, (Id, Id)>,
         pos: u32,
         i: &ir::Instr<'cc>,
     ) {
@@ -271,7 +271,7 @@ impl<'cc> Cc<'cc> {
                 let pc = func.pc;
 
                 let mut alive_after_call_spill = vec![];
-                for (v, (def, last_use)) in live_set {
+                for (Id(v), (Id(def), Id(last_use))) in live_set {
                     // the value is defined before the call and used after the call, thus must be
                     // spilled
                     if def < &pos && &pos < last_use {

--- a/src/bc/mod.rs
+++ b/src/bc/mod.rs
@@ -224,6 +224,21 @@ impl<'cc> Cc<'cc> {
                     target: no.0 as u16,
                 });
             }
+            ir::Terminator::Tail { func, args } => {
+                let Some(func) = self.functions.get(func) else {
+                    unreachable!();
+                };
+
+                let pc = func.pc;
+                for (i, arg) in args.iter().enumerate() {
+                    let (dst, src) = (i as u8, self.ensure_register(*arg));
+                    if dst != src {
+                        self.emit(Op::Mov { dst, src });
+                    }
+                }
+
+                self.emit(Op::Tail { func: pc as u32 });
+            }
         }
     }
 
@@ -305,21 +320,6 @@ impl<'cc> Cc<'cc> {
                 for dst in alive_after_call_spill.iter().rev() {
                     self.emit(Op::Pop { dst: *dst });
                 }
-            }
-            ir::Instr::Tail { dst, func, args } => {
-                let Some(func) = self.functions.get(func) else {
-                    unreachable!();
-                };
-
-                let pc = func.pc;
-                for (i, arg) in args.iter().enumerate() {
-                    let (dst, src) = (i as u8, self.ensure_register(*arg));
-                    if dst != src {
-                        self.emit(Op::Mov { dst, src });
-                    }
-                }
-
-                self.emit(Op::Tail { func: pc as u32 });
             }
             ir::Instr::Sys {
                 dst,

--- a/src/bc/mod.rs
+++ b/src/bc/mod.rs
@@ -91,10 +91,10 @@ impl<'cc> Cc<'cc> {
         // values at the same time
 
         let live_set = fun.live_set();
-        crate::trace!("Computed live_set for {}: {:?}", fun.name, live_set);
+        crate::trace!("[bc::Cc::cc][{}] live_set: {:#?}", fun.name, live_set);
         self.regalloc = Ralloc::new(&live_set);
         crate::trace!(
-            "[bc] Computed ralloc map for `{}`: {:#?}",
+            "[bc::Cc::cc][{}] regalloc map: {:#?}",
             fun.name,
             &self.regalloc.map
         );
@@ -118,11 +118,7 @@ impl<'cc> Cc<'cc> {
             self.term(fun, block.term.as_ref());
         }
 
-        crate::trace!(
-            "[bc] compiled `{}` (size={})",
-            fun.name,
-            self.buf.len() - pc
-        );
+        crate::trace!("[bc::Cc::cc][{}] size={}", fun.name, self.buf.len() - pc);
 
         Ok(())
     }

--- a/src/bc/mod.rs
+++ b/src/bc/mod.rs
@@ -389,11 +389,12 @@ impl<'cc> Cc<'cc> {
                 Op::Jmp { target } => {
                     let target = *self.block_map.get(&ir::Id(target as u32)).unwrap();
                     // PERF: this removes self+1 jumps
-                    Some(if target == i as u16 + 1 {
-                        Op::Nop
-                    } else {
-                        Op::Jmp { target }
-                    })
+                    Some(
+                        /*if target == i as u16 + 1 {
+                            Op::Nop
+                        } else {*/
+                        Op::Jmp { target }, /*}*/
+                    )
                 }
                 _ => None,
             } {

--- a/src/bc/mod.rs
+++ b/src/bc/mod.rs
@@ -6,7 +6,7 @@ mod regalloc;
 
 use crate::{
     bc::{intern::Interner, regalloc::Ralloc},
-    config::Config,
+    config::{self, Config},
     err::PgError,
     ir::{self, Const, Func, Id, TypeId, ptype},
     opt,
@@ -77,8 +77,20 @@ impl<'cc> Cc<'cc> {
     }
 
     /// Compile a list of ir functions to bytecode instructions
-    pub fn compile(&mut self, ir: &[Func<'cc>]) -> Result<(), PgError> {
+    pub fn compile(&mut self, conf: &config::Config, ir: &[Func<'cc>]) -> Result<(), PgError> {
         for func in ir {
+            if conf.liveness {
+                let intervals = func.live_set();
+                let mut entries: Vec<_> = intervals.iter().collect();
+                entries.sort_by_key(|(id, _)| *id);
+                println!(
+                    "{}",
+                    entries
+                        .into_iter()
+                        .map(|(id, (def, last_use))| format!("{id}: ({def},{last_use})\n"))
+                        .collect::<String>()
+                )
+            }
             self.cc(func)?;
         }
         Ok(())
@@ -91,7 +103,6 @@ impl<'cc> Cc<'cc> {
         // values at the same time
 
         let live_set = fun.live_set();
-        crate::trace!("[bc::Cc::cc][{}] live_set: {:#?}", fun.name, live_set);
         self.regalloc = Ralloc::new(&live_set);
         crate::trace!(
             "[bc::Cc::cc][{}] regalloc map: {:#?}",

--- a/src/bc/regalloc.rs
+++ b/src/bc/regalloc.rs
@@ -1,4 +1,4 @@
-use crate::vm;
+use crate::{ir::Id, vm};
 use std::collections::HashMap;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,13 +32,13 @@ pub struct Ralloc {
 }
 
 impl Ralloc {
-    pub fn new(live_set: &HashMap<u32, (u32, u32)>) -> Self {
+    pub fn new(live_set: HashMap<Id, (Id, Id)>) -> Self {
         let mut intervals: Vec<Interval> = live_set
-            .iter()
-            .map(|(v, (start, end))| Interval {
-                v: *v,
-                start: *start,
-                end: *end,
+            .into_iter()
+            .map(|(Id(v), (Id(start), Id(end)))| Interval {
+                v,
+                start,
+                end,
                 reg: None,
             })
             .collect();
@@ -84,18 +84,21 @@ impl Ralloc {
 
 #[cfg(test)]
 mod regalloc_test {
-    use crate::bc::regalloc::{Location, Ralloc};
+    use crate::{
+        bc::regalloc::{Location, Ralloc},
+        ir::Id,
+    };
 
     #[test]
     fn non_overlapping_reuses_registers() {
         let mut live_set = std::collections::HashMap::new();
 
         // v0: [0, 2]
-        live_set.insert(0, (0, 2));
+        live_set.insert(Id(0), (Id(0), Id(2)));
         // v1: [3, 5]
-        live_set.insert(1, (3, 5));
+        live_set.insert(Id(1), (Id(3), Id(5)));
 
-        let ralloc = Ralloc::new(&live_set);
+        let ralloc = Ralloc::new(live_set);
 
         let loc0 = ralloc.map.get(&0).unwrap();
         let loc1 = ralloc.map.get(&1).unwrap();
@@ -114,11 +117,11 @@ mod regalloc_test {
         let mut live_set = std::collections::HashMap::new();
 
         // v0: [0, 5]
-        live_set.insert(0, (0, 5));
+        live_set.insert(Id(0), (Id(0), Id(5)));
         // v1: [2, 6] overlaps with v0
-        live_set.insert(1, (2, 6));
+        live_set.insert(Id(1), (Id(2), Id(6)));
 
-        let ralloc = Ralloc::new(&live_set);
+        let ralloc = Ralloc::new(live_set);
 
         let loc0 = ralloc.map.get(&0).unwrap();
         let loc1 = ralloc.map.get(&1).unwrap();
@@ -139,10 +142,10 @@ mod regalloc_test {
 
         // Create more intervals than registers
         for i in 0..reg_count + 2 {
-            live_set.insert(i as u32, (0, 10));
+            live_set.insert(Id(i as u32), (Id(0), Id(10)));
         }
 
-        let ralloc = Ralloc::new(&live_set);
+        let ralloc = Ralloc::new(live_set);
 
         let mut reg_assigned = 0;
         let mut spilled = 0;
@@ -166,10 +169,10 @@ mod regalloc_test {
         let mut live_set = std::collections::HashMap::new();
 
         for i in 0..10 {
-            live_set.insert(i, (i, i + 1));
+            live_set.insert(Id(i), (Id(i), Id(i + 1)));
         }
 
-        let ralloc = Ralloc::new(&live_set);
+        let ralloc = Ralloc::new(live_set);
 
         for i in 0..10 {
             assert!(
@@ -185,12 +188,12 @@ mod regalloc_test {
         let mut live_set = std::collections::HashMap::new();
 
         // overlapping chain
-        live_set.insert(0, (0, 10));
-        live_set.insert(1, (1, 9));
-        live_set.insert(2, (2, 8));
-        live_set.insert(3, (3, 7));
+        live_set.insert(Id(0), (Id(0), Id(10)));
+        live_set.insert(Id(1), (Id(1), Id(9)));
+        live_set.insert(Id(2), (Id(2), Id(8)));
+        live_set.insert(Id(3), (Id(3), Id(7)));
 
-        let ralloc = Ralloc::new(&live_set);
+        let ralloc = Ralloc::new(live_set);
 
         let mut active: Vec<(u32, u32, u8)> = vec![];
 

--- a/src/bin/livesetvis.rs
+++ b/src/bin/livesetvis.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, fs};
+
+macro_rules! livesetvisprintln {
+        ($fmt:literal, $($value:expr),*) => {
+            {
+                println!("[livesetvis] {}", format_args!($fmt, $($value),*));
+            }
+        };
+        ($fmt:literal) => {
+            {
+                println!("[livesetvis] {}", $fmt);
+            }
+        };
+    }
+
+fn parse_live_intervals(raw: &str) -> HashMap<u32, (u32, u32)> {
+    raw.lines()
+        .filter_map(|l| {
+            // each line is: <%v>: (<def>,<last_use>)
+            let (lhs, rhs) = l.split_once(":")?;
+            let v = lhs.parse().ok()?;
+            let (def, last_use) = rhs.trim_ascii().split_once(',')?;
+            let (def, last_use) = (
+                def[1..].parse().ok()?,
+                last_use[..last_use.len() - 1].parse().ok()?,
+            );
+            Some((v, (def, last_use)))
+        })
+        .collect()
+}
+
+fn visualize(parsed: HashMap<u32, (u32, u32)>) {
+    let max_end = parsed.values().map(|(_, end)| *end).max().unwrap_or(0);
+    let mut entries: Vec<_> = parsed.iter().collect();
+    entries.sort_by_key(|(id, _)| *id);
+
+    print!("   ");
+    for i in 0..max_end {
+        print!("{:2} ", i);
+    }
+    println!();
+
+    for (id, (start, end)) in entries {
+        print!("v{:<3}", id);
+
+        for i in 0..max_end {
+            if i >= *start && i < *end {
+                print!("X  ");
+            } else {
+                print!("   ");
+            }
+        }
+
+        println!("  [{}..{})", start, end);
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_name = std::env::args().nth(1).unwrap();
+    let bytes = fs::read(file_name)?;
+    let s = str::from_utf8(&bytes.trim_ascii())?;
+    let parsed = parse_live_intervals(s);
+    visualize(parsed);
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,9 @@ pub struct Config {
     /// Readable immediate representation
     #[arg(short = 'I', long)]
     pub ir: bool,
+    /// Dump liveness as <%v>: (<def>,<last_use>)
+    #[arg(short = 'L', long)]
+    pub liveness: bool,
     /// Generate backtraces for function calls
     ///
     /// Technically a brain child of my interview at apple in which we talked about ways of implementing
@@ -95,6 +98,7 @@ impl Config {
             target: None,
             command: None,
             version: 0,
+            liveness: todo!(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,7 @@ impl Config {
             target: None,
             command: None,
             version: 0,
-            liveness: todo!(),
+            liveness: false,
         }
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -3,6 +3,7 @@ use crate::{
     lex::{Token, Type},
     vm::Anomaly,
 };
+use std::fmt::Write;
 
 #[derive(Debug)]
 pub struct PgError {
@@ -50,14 +51,20 @@ impl From<Anomaly> for PgError {
 }
 
 impl PgError {
-    // TODO: introduce a writer to write errors to?
-    pub fn render(self, file: &str, lines: &[&str]) {
-        println!("{file}:{}:{}: {}:", self.line, self.start, self.msg);
+    pub fn render(self, file: &str, lines: &[&str]) -> String {
+        let mut buf = String::new();
+        writeln!(
+            &mut buf,
+            "{file}:{}:{}: {}:",
+            self.line, self.start, self.msg
+        );
 
         if let Some(line) = lines.get(self.line) {
-            println!("{line}");
-            println!("{}~", " ".repeat(self.start))
-        }
+            writeln!(&mut buf, "{line}");
+            writeln!(&mut buf, "{}~", " ".repeat(self.start));
+        };
+
+        buf
     }
 
     pub fn with_msg(msg: impl Into<String>, from: impl Into<PgError>) -> Self {

--- a/src/input.rs
+++ b/src/input.rs
@@ -35,7 +35,7 @@ impl Input {
                 0,
             )
             .expect("Failed to memory map file");
-            crate::trace!("mmaped the file");
+            crate::trace!("[input::Input::from_file] mmaped the file");
             Self::MmapedFile { file, len, ptr }
         }
 

--- a/src/ir/display.rs
+++ b/src/ir/display.rs
@@ -51,18 +51,6 @@ impl Display for Instr<'_> {
                 }
                 write!(f, ")")?;
             }
-            Instr::Tail { dst, func, args } => {
-                write!(f, "%v{} = ", dst)?;
-                write!(f, "Tailcall f{}(", func.0)?;
-                for (i, arg) in args.iter().enumerate() {
-                    if i + 1 == args.len() {
-                        write!(f, "%v{}", arg.0)?;
-                    } else {
-                        write!(f, "%v{}, ", arg.0)?;
-                    }
-                }
-                write!(f, ")")?;
-            }
             Instr::Cast { dst: value, from } => {
                 write!(f, "%v{} = Cast_to_{} %v{}", value, value.ty, from.0)?
             }
@@ -108,6 +96,17 @@ impl Display for Terminator {
                     .collect::<Vec<_>>()
                     .join(", "),
             )?,
+            Terminator::Tail { func, args } => {
+                write!(f, "tail f{}(", func.0)?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i + 1 == args.len() {
+                        write!(f, "%v{}", arg.0)?;
+                    } else {
+                        write!(f, "%v{}, ", arg.0)?;
+                    }
+                }
+                write!(f, ")")?;
+            }
         }
         Ok(())
     }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -465,7 +465,7 @@ impl<'lower> Lower<'lower> {
         for node in ast {
             let _t = typechecker.node(node)?;
         }
-        crate::trace!("Finished type checking");
+        crate::trace!("[ir::lower::Lower::ir_from] Finished type checking");
         self.types = typechecker.finalise();
 
         self.ctx.func = Func {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -139,89 +139,21 @@ pub struct Func<'f> {
 }
 
 impl Func<'_> {
-    // TODO: rework this to work in reverse, last use and first def should be easier to compute,
-    // since the value id is the definition and the first seen usage is the last usage
-
-    /// mapping any vN to (def, last_use), used for spill detection for preserving registers around
-    /// call boundaries, since all registers in pg are callersaved (def(v) lteq C lt last_use(v)).
-    pub fn live_set(&self) -> HashMap<u32, (u32, u32)> {
-        let mut def = HashMap::new();
-        let mut last_use = HashMap::new();
-        let mut live_set = HashMap::new();
-
-        let mut idx = 0;
-        for param in &self.params {
-            def.insert(param.0, idx);
-            last_use.entry(param.0).or_insert(idx);
+    /// Map VReg to its (start, end)
+    pub fn live_set(&self) -> HashMap<Id, (Id, Id)> {
+        struct Liveness {
+            /// LiveIn[B]: set of VRegs alive at B entry
+            live_in: HashMap<Id, Vec<Id>>,
+            /// LiveOut[B]: set of VRegs alive at B exit
+            live_out: HashMap<Id, Vec<Id>>,
         }
 
-        for block in &self.blocks {
-            for instr in &block.instructions {
-                match instr {
-                    Instr::Bin { dst, lhs, rhs, .. } => {
-                        last_use.insert(lhs.0, idx);
-                        last_use.insert(rhs.0, idx);
-
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    Instr::LoadConst { dst, .. } => {
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    Instr::Call { dst, args, .. }
-                    | Instr::Sys { dst, args, .. }
-                    | Instr::Tail { dst, args, .. } => {
-                        for arg in args {
-                            last_use.insert(arg.0, idx);
-                        }
-
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    Instr::Cast { dst, from } => {
-                        last_use.insert(from.0, idx);
-
-                        def.insert(dst.id.0, idx);
-                        last_use.entry(dst.id.0).or_insert(idx);
-                    }
-                    _ => unreachable!(),
-                }
-
-                idx += 1;
-            }
-
-            if let Some(term) = &block.term {
-                match term {
-                    Terminator::Return(Some(Id(id))) => {
-                        last_use.insert(*id, idx);
-                    }
-                    Terminator::Jump { params, .. } => {
-                        for id in params {
-                            last_use.insert(id.0, idx);
-                        }
-                    }
-                    Terminator::Branch { cond, yes, no } => {
-                        last_use.insert(cond.0, idx);
-
-                        for id in &yes.1 {
-                            last_use.insert(id.0, idx);
-                        }
-
-                        for id in &no.1 {
-                            last_use.insert(id.0, idx);
-                        }
-                    }
-                    _ => (),
-                }
-            }
+        for b in &self.blocks {
+            let live_in = &b.params;
+            let live_out = &b.term;
+            dbg!((live_in, live_out));
         }
 
-        for (v, d) in def {
-            let l = last_use.get(&v).copied().unwrap_or(d);
-            live_set.insert(v, (d, l));
-        }
-
-        live_set
+        HashMap::new()
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -91,11 +91,6 @@ pub enum Instr<'i> {
         func: &'i pstd::Fn,
         args: Vec<Id>,
     },
-    Tail {
-        dst: TypeId,
-        func: Id,
-        args: Vec<Id>,
-    },
     Cast {
         dst: TypeId,
         from: Id,
@@ -114,6 +109,10 @@ pub enum Terminator {
         cond: Id,
         yes: (Id, Vec<Id>),
         no: (Id, Vec<Id>),
+    },
+    Tail {
+        func: Id,
+        args: Vec<Id>,
     },
 }
 
@@ -151,7 +150,6 @@ impl Func<'_> {
             | Instr::LoadConst { dst, .. }
             | Instr::Call { dst, .. }
             | Instr::Sys { dst, .. }
-            | Instr::Tail { dst, .. }
             | Instr::Cast { dst, .. } => Some(dst.id),
             Instr::Noop => None,
         }
@@ -160,9 +158,7 @@ impl Func<'_> {
     fn uses_of_instr(instr: &Instr<'_>) -> Vec<Id> {
         match instr {
             Instr::Bin { lhs, rhs, .. } => vec![*lhs, *rhs],
-            Instr::Call { args, .. } | Instr::Sys { args, .. } | Instr::Tail { args, .. } => {
-                args.clone()
-            }
+            Instr::Call { args, .. } | Instr::Sys { args, .. } => args.clone(),
             Instr::Cast { from, .. } => vec![*from],
             Instr::LoadConst { .. } | Instr::Noop => vec![],
         }
@@ -173,6 +169,7 @@ impl Func<'_> {
             Terminator::Return(Some(id)) => vec![*id],
             Terminator::Return(None) => vec![],
             Terminator::Jump { params, .. } => params.clone(),
+            Terminator::Tail { args, .. } => args.clone(),
             Terminator::Branch {
                 cond,
                 yes: (_, yes_params),
@@ -191,6 +188,7 @@ impl Func<'_> {
         match term {
             Terminator::Return(Some(id)) => vec![*id],
             Terminator::Return(None) | Terminator::Jump { .. } => vec![],
+            Terminator::Tail { args, .. } => args.clone(),
             Terminator::Branch { cond, .. } => vec![*cond],
         }
     }
@@ -211,7 +209,7 @@ impl Func<'_> {
                     args: no.1.clone(),
                 },
             ],
-            Some(Terminator::Return(_)) | None => vec![],
+            Some(Terminator::Return(_) | Terminator::Tail { .. }) | None => vec![],
         }
     }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -24,7 +24,7 @@ pub mod lower;
 pub mod ptype;
 pub mod typecheck;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ir::ptype::Type;
 use crate::std as pstd;
@@ -138,27 +138,296 @@ pub struct Func<'f> {
     pub blocks: Vec<Block<'f>>,
 }
 
+#[derive(Debug, Clone)]
+struct Edge {
+    to: Id,
+    args: Vec<Id>,
+}
+
 impl Func<'_> {
+    fn def_of(instr: &Instr<'_>) -> Option<Id> {
+        match instr {
+            Instr::Bin { dst, .. }
+            | Instr::LoadConst { dst, .. }
+            | Instr::Call { dst, .. }
+            | Instr::Sys { dst, .. }
+            | Instr::Tail { dst, .. }
+            | Instr::Cast { dst, .. } => Some(dst.id),
+            Instr::Noop => None,
+        }
+    }
+
+    fn uses_of_instr(instr: &Instr<'_>) -> Vec<Id> {
+        match instr {
+            Instr::Bin { lhs, rhs, .. } => vec![*lhs, *rhs],
+            Instr::Call { args, .. } | Instr::Sys { args, .. } | Instr::Tail { args, .. } => {
+                args.clone()
+            }
+            Instr::Cast { from, .. } => vec![*from],
+            Instr::LoadConst { .. } | Instr::Noop => vec![],
+        }
+    }
+
+    fn uses_of_term(term: &Terminator) -> Vec<Id> {
+        match term {
+            Terminator::Return(Some(id)) => vec![*id],
+            Terminator::Return(None) => vec![],
+            Terminator::Jump { params, .. } => params.clone(),
+            Terminator::Branch {
+                cond,
+                yes: (_, yes_params),
+                no: (_, no_params),
+            } => {
+                let mut uses = Vec::with_capacity(1 + yes_params.len() + no_params.len());
+                uses.push(*cond);
+                uses.extend(yes_params.iter().copied());
+                uses.extend(no_params.iter().copied());
+                uses
+            }
+        }
+    }
+
+    fn local_term_uses(term: &Terminator) -> Vec<Id> {
+        match term {
+            Terminator::Return(Some(id)) => vec![*id],
+            Terminator::Return(None) | Terminator::Jump { .. } => vec![],
+            Terminator::Branch { cond, .. } => vec![*cond],
+        }
+    }
+
+    fn successors(term: Option<&Terminator>) -> Vec<Edge> {
+        match term {
+            Some(Terminator::Jump { id, params }) => vec![Edge {
+                to: *id,
+                args: params.clone(),
+            }],
+            Some(Terminator::Branch { yes, no, .. }) => vec![
+                Edge {
+                    to: yes.0,
+                    args: yes.1.clone(),
+                },
+                Edge {
+                    to: no.0,
+                    args: no.1.clone(),
+                },
+            ],
+            Some(Terminator::Return(_)) | None => vec![],
+        }
+    }
+
     pub fn live_set(&self) -> HashMap<Id, (Id, Id)> {
         // PERF: this whole process should be a set theory based bit set, since we have at most 64
         // registers (i think?), thus a BitSet(u64) should be a perfect abstraction
 
-        struct Liveness {
-            /// LiveIn[B]: set of VRegs alive at B entry
-            live_in: HashMap<Id, Vec<Id>>,
-            /// LiveOut[B]: set of VRegs alive at B exit
-            live_out: HashMap<Id, Vec<Id>>,
+        fn define(intervals: &mut HashMap<Id, (Id, Id)>, id: Id, pos: u32, reason: String) {
+            crate::trace!("[ir::Func::live_set] def %v{} @{} ({})", id.0, pos, reason);
+            intervals
+                .entry(id)
+                .and_modify(|(def, last_use)| {
+                    def.0 = def.0.min(pos);
+                    last_use.0 = last_use.0.max(pos);
+                })
+                .or_insert((Id(pos), Id(pos)));
         }
 
-        for b in &self.blocks {
-            // defs are both block params and each instruction
-
-            let live_in = &b.params;
-            let live_out = &b.term;
-
-            // TODO:
+        fn use_value(intervals: &mut HashMap<Id, (Id, Id)>, id: Id, pos: u32, reason: String) {
+            crate::trace!("[ir::Func::live_set] use %v{} @{} ({})", id.0, pos, reason);
+            intervals
+                .entry(id)
+                .and_modify(|(_, last_use)| last_use.0 = last_use.0.max(pos))
+                .or_insert((Id(pos), Id(pos)));
         }
 
-        HashMap::new()
+        crate::trace!("[ir::Func::live_set][{}] start", self.name);
+
+        let mut intervals = HashMap::new();
+        let mut pos = 0;
+
+        for block in &self.blocks {
+            if block.tombstone {
+                crate::trace!(
+                    "[ir::Func::live_set][{}] skip tombstone b{}",
+                    self.name,
+                    block.id.0
+                );
+                continue;
+            }
+
+            crate::trace!(
+                "[ir::Func::live_set][{}] b{} entry @{}",
+                self.name,
+                block.id.0,
+                pos
+            );
+            for param in &block.params {
+                define(
+                    &mut intervals,
+                    *param,
+                    pos,
+                    format!("b{} param", block.id.0),
+                );
+            }
+            pos += 1;
+
+            for instr in &block.instructions {
+                crate::trace!(
+                    "[ir::Func::live_set][{}] b{} instr @{}: {}",
+                    self.name,
+                    block.id.0,
+                    pos,
+                    instr
+                );
+
+                for use_id in Self::uses_of_instr(instr) {
+                    use_value(
+                        &mut intervals,
+                        use_id,
+                        pos,
+                        format!("b{} instr {}", block.id.0, instr),
+                    );
+                }
+
+                if let Some(def_id) = Self::def_of(instr) {
+                    define(
+                        &mut intervals,
+                        def_id,
+                        pos,
+                        format!("b{} instr {}", block.id.0, instr),
+                    );
+                }
+                pos += 1;
+            }
+
+            if let Some(term) = &block.term {
+                crate::trace!(
+                    "[ir::Func::live_set][{}] b{} term @{}: {}",
+                    self.name,
+                    block.id.0,
+                    pos,
+                    term
+                );
+
+                for use_id in Self::uses_of_term(term) {
+                    use_value(
+                        &mut intervals,
+                        use_id,
+                        pos,
+                        format!("b{} term {}", block.id.0, term),
+                    );
+                }
+            } else {
+                crate::trace!(
+                    "[ir::Func::live_set][{}] b{} has no terminator @{}",
+                    self.name,
+                    block.id.0,
+                    pos
+                );
+            }
+            pos += 1;
+        }
+
+        #[cfg(feature = "trace")]
+        {
+            let mut ordered: Vec<_> = intervals.iter().collect();
+            ordered.sort_by_key(|(id, _)| id.0);
+            for (id, (def, last_use)) in ordered {
+                crate::trace!(
+                    "[ir::Func::live_set][{}] interval %v{} = ({}..{})",
+                    self.name,
+                    id.0,
+                    def.0,
+                    last_use.0
+                );
+            }
+        }
+
+        intervals
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ptype::Type, *};
+    use std::collections::HashSet;
+
+    fn type_id(id: u32) -> TypeId {
+        TypeId {
+            id: Id(id),
+            ty: Type::Int,
+        }
+    }
+
+    fn ids(ids: &[u32]) -> HashSet<Id> {
+        ids.iter().copied().map(Id).collect()
+    }
+
+    fn empty_block(id: u32, params: Vec<Id>, term: Terminator) -> Block<'static> {
+        Block {
+            tombstone: false,
+            id: Id(id),
+            params,
+            instructions: vec![],
+            term: Some(term),
+        }
+    }
+
+    #[test]
+    fn live_set_tracks_block_params_instructions_and_terminators() {
+        let fun = Func {
+            name: "live",
+            id: Id(0),
+            params: vec![Id(0)],
+            ret: Some(Type::Int),
+            blocks: vec![
+                Block {
+                    tombstone: false,
+                    id: Id(0),
+                    params: vec![Id(0)],
+                    instructions: vec![
+                        Instr::LoadConst {
+                            dst: type_id(1),
+                            value: Const::Int(1),
+                        },
+                        Instr::Bin {
+                            op: BinOp::IAdd,
+                            dst: type_id(2),
+                            lhs: Id(0),
+                            rhs: Id(1),
+                        },
+                    ],
+                    term: Some(Terminator::Branch {
+                        cond: Id(2),
+                        yes: (Id(1), vec![Id(0)]),
+                        no: (Id(2), vec![Id(1)]),
+                    }),
+                },
+                Block {
+                    tombstone: false,
+                    id: Id(1),
+                    params: vec![Id(3)],
+                    instructions: vec![],
+                    term: Some(Terminator::Return(Some(Id(3)))),
+                },
+                Block {
+                    tombstone: false,
+                    id: Id(2),
+                    params: vec![Id(4)],
+                    instructions: vec![Instr::Cast {
+                        dst: type_id(5),
+                        from: Id(4),
+                    }],
+                    term: Some(Terminator::Return(Some(Id(5)))),
+                },
+            ],
+        };
+
+        let live_set = fun.live_set();
+
+        assert_eq!(live_set.get(&Id(0)), Some(&(Id(0), Id(3))));
+        assert_eq!(live_set.get(&Id(1)), Some(&(Id(1), Id(3))));
+        assert_eq!(live_set.get(&Id(2)), Some(&(Id(2), Id(3))));
+        assert_eq!(live_set.get(&Id(3)), Some(&(Id(4), Id(5))));
+        assert_eq!(live_set.get(&Id(4)), Some(&(Id(6), Id(7))));
+        assert_eq!(live_set.get(&Id(5)), Some(&(Id(7), Id(8))));
     }
 }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -139,6 +139,9 @@ pub struct Func<'f> {
 }
 
 impl Func<'_> {
+    // TODO: rework this to work in reverse, last use and first def should be easier to compute,
+    // since the value id is the definition and the first seen usage is the last usage
+
     /// mapping any vN to (def, last_use), used for spill detection for preserving registers around
     /// call boundaries, since all registers in pg are callersaved (def(v) lteq C lt last_use(v)).
     pub fn live_set(&self) -> HashMap<u32, (u32, u32)> {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -41,7 +41,7 @@ pub enum Const<'c> {
     Str(&'c str),
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Id(pub u32);
 
 #[derive(Debug, Clone)]
@@ -139,8 +139,10 @@ pub struct Func<'f> {
 }
 
 impl Func<'_> {
-    /// Map VReg to its (start, end)
     pub fn live_set(&self) -> HashMap<Id, (Id, Id)> {
+        // PERF: this whole process should be a set theory based bit set, since we have at most 64
+        // registers (i think?), thus a BitSet(u64) should be a perfect abstraction
+
         struct Liveness {
             /// LiveIn[B]: set of VRegs alive at B entry
             live_in: HashMap<Id, Vec<Id>>,
@@ -149,9 +151,12 @@ impl Func<'_> {
         }
 
         for b in &self.blocks {
+            // defs are both block params and each instruction
+
             let live_in = &b.params;
             let live_out = &b.term;
-            dbg!((live_in, live_out));
+
+            // TODO:
         }
 
         HashMap::new()

--- a/src/ir/typecheck.rs
+++ b/src/ir/typecheck.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use crate::{
     ast::Node,
@@ -29,6 +29,21 @@ pub fn id_from_node(node: &Node) -> Option<usize> {
 struct FunctionType {
     args: Vec<Type>,
     ret: Type,
+}
+
+impl Display for FunctionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(")?;
+        for (i, t) in self.args.iter().enumerate() {
+            if i + 1 == self.args.len() {
+                write!(f, "{t}")?;
+            } else {
+                write!(f, "{t} ")?;
+            }
+        }
+        write!(f, ") -> {}", self.ret)?;
+        Ok(())
+    }
 }
 
 #[derive(Default, Debug)]
@@ -261,20 +276,17 @@ impl<'t> Typechecker<'t> {
                 }
 
                 let ret: Type = return_type.into();
-
-                self.functions.insert(
-                    inner_name,
-                    FunctionType {
-                        args: typed_arguments,
-                        ret: ret.clone(),
-                    },
-                );
+                let f_type = FunctionType {
+                    args: typed_arguments,
+                    ret: ret.clone(),
+                };
+                self.functions.insert(inner_name, f_type.clone());
 
                 let computed_ret = self.block_type(body)?;
                 if ret != computed_ret {
                     return Err(PgError::with_msg(
                         format!(
-                            "`{}` annotated with return type {}, but returns {}",
+                            "`{}` should return {}, but returns {}",
                             inner_name, ret, computed_ret
                         ),
                         return_type,
@@ -282,7 +294,11 @@ impl<'t> Typechecker<'t> {
                 }
 
                 self.env = prev_env;
-                crate::trace!("[ty]: typechecked function `{}`", inner_name);
+                crate::trace!(
+                    "[ir::typecheck::Typechecker::node][{}]: {}",
+                    inner_name,
+                    f_type
+                );
                 ret
             }
             Node::Cast { id, lhs, rhs, src } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub fn new<'e>(config: &'e config::Config, input: &'e [u8]) -> Result<Vm<'e>, Pg
     }
 
     let mut cc = bc::Cc::new();
-    cc.compile(&ir)?;
+    cc.compile(&config, &ir)?;
     if config.opt >= 1 {
         opt::bc(&mut cc.buf);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ pub const BUILD_INFO: &str = concat!(
 );
 
 fn main() {
-    let args = <config::Config as clap::Parser>::parse();
-    match args.version {
+    let conf = <config::Config as clap::Parser>::parse();
+    match conf.version {
         1 => {
             println!(
                 "purple-garden version {} by xnacly and contributors",
@@ -47,7 +47,7 @@ fn main() {
         }
         _ => {}
     }
-    if let Some(ref cmd) = args.command {
+    if let Some(ref cmd) = conf.command {
         match &cmd {
             config::Command::Intro { topic } => {
                 println!(
@@ -103,10 +103,10 @@ fn main() {
         }
     }
 
-    let (input, input_source) = match args.run {
+    let (input, input_source) = match conf.run {
         Some(ref i) => (Input::Str(i.clone()), "stdio"),
         None => {
-            let file_name = args
+            let file_name = conf
                 .target
                 .as_ref()
                 .expect("No file or `-r` specified")
@@ -131,7 +131,7 @@ fn main() {
 
     trace!("[main] Tokenisation and Parsing done");
 
-    if args.ast {
+    if conf.ast {
         print!(
             "{}",
             ast.iter()
@@ -153,18 +153,18 @@ fn main() {
 
     trace!("[main] Lowered AST to IR");
 
-    if args.opt >= 1 {
+    if conf.opt >= 1 {
         opt::ir(&mut ir);
     }
 
-    if args.ir {
+    if conf.ir {
         for func in ir.iter() {
             println!("{func}");
         }
     }
 
     let mut cc = bc::Cc::new();
-    if let Err(e) = cc.compile(&ir) {
+    if let Err(e) = cc.compile(&conf, &ir) {
         let lines = input.as_str().lines().collect::<Vec<&str>>();
         e.render(input_source, &lines);
         std::process::exit(1);
@@ -172,28 +172,28 @@ fn main() {
 
     trace!("[main] Lowered IR to bytecode");
 
-    if args.opt >= 1 {
+    if conf.opt >= 1 {
         opt::bc(&mut cc.buf);
     }
 
-    let function_table = if args.backtrace {
+    let function_table = if conf.backtrace {
         cc.function_table()
     } else {
         HashMap::new()
     };
 
-    let ctx = if args.disassemble {
+    let ctx = if conf.disassemble {
         Some(cc.clone())
     } else {
         None
     };
-    let mut vm = cc.finalize(&args);
+    let mut vm = cc.finalize(&conf);
 
-    if args.disassemble {
+    if conf.disassemble {
         bc::dis::Disassembler::new(&vm.bytecode, ctx.unwrap()).disassemble();
     }
 
-    if args.dry {
+    if conf.dry {
         return;
     }
 
@@ -201,7 +201,7 @@ fn main() {
         let lines = input.as_str().lines().collect::<Vec<&str>>();
         Into::<PgError>::into(e).render(input_source, &lines);
 
-        if args.backtrace {
+        if conf.backtrace {
             let entry_point_pc = function_table
                 .iter()
                 .find(|(_, name)| name.as_str() == "entry")

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn main() {
         }
     };
 
-    trace!("Tokenisation and Parsing done");
+    trace!("[main] Tokenisation and Parsing done");
 
     if args.ast {
         print!(
@@ -151,7 +151,7 @@ fn main() {
         }
     };
 
-    trace!("Lowered AST to IR");
+    trace!("[main] Lowered AST to IR");
 
     if args.opt >= 1 {
         opt::ir(&mut ir);
@@ -170,7 +170,7 @@ fn main() {
         std::process::exit(1);
     };
 
-    trace!("Lowered IR to bytecode");
+    trace!("[main] Lowered IR to bytecode");
 
     if args.opt >= 1 {
         opt::bc(&mut cc.buf);
@@ -219,5 +219,5 @@ fn main() {
         }
     }
 
-    trace!("Executed bytecode");
+    trace!("[main] Executed bytecode");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,13 @@ pub const BUILD_INFO: &str = concat!(
     env!("BUILD_PROFILE"),
 );
 
-fn main() {
+macro_rules! err {
+    ($msg:expr) => {
+        Err($msg.into())
+    };
+}
+
+fn entry() -> Result<(), Box<dyn std::error::Error>> {
     let conf = <config::Config as clap::Parser>::parse();
     match conf.version {
         1 => {
@@ -33,7 +39,7 @@ fn main() {
                 "purple-garden version {} by xnacly and contributors",
                 env!("CARGO_PKG_VERSION")
             );
-            std::process::exit(0);
+            return Ok(());
         }
         2 => {
             println!(
@@ -43,10 +49,11 @@ fn main() {
             println!("{}", BUILD_INFO.replace(";", "\n"));
             let exe = std::env::current_exe().unwrap();
             println!("from={}", exe.display());
-            std::process::exit(0);
+            return Ok(());
         }
         _ => {}
     }
+
     if let Some(ref cmd) = conf.command {
         match &cmd {
             config::Command::Intro { topic } => {
@@ -78,22 +85,15 @@ fn main() {
                     None => (pkg_or_function.as_str(), None),
                 };
 
-                let pkg = pstd::resolve_pkg(path).unwrap_or_else(|| {
-                    eprintln!("query {} couldnt be resolved to anything", path);
-                    std::process::exit(1);
-                });
+                let Some(pkg) = pstd::resolve_pkg(path) else {
+                    return err!(format!("query {} couldnt be resolved to anything", path));
+                };
 
                 if let Some(method) = method {
-                    println!(
-                        "{}",
-                        pkg.fns
-                            .iter()
-                            .find(|f| f.name == method)
-                            .unwrap_or_else(|| {
-                                eprintln!("function {}.{} not found", pkg.name, method);
-                                std::process::exit(1);
-                            })
-                    );
+                    let Some(fun) = pkg.fns.iter().find(|f| f.name == method) else {
+                        return err!(format!("function {}.{} not found", pkg.name, method));
+                    };
+                    println!("{fun}",);
                 } else {
                     println!("{}", pkg);
                 }
@@ -106,17 +106,15 @@ fn main() {
     let (input, input_source) = match conf.run {
         Some(ref i) => (Input::Str(i.clone()), "stdio"),
         None => {
-            let file_name = conf
-                .target
-                .as_ref()
-                .expect("No file or `-r` specified")
-                .as_str();
+            let Some(file_name) = conf.target.as_ref().map(|f| f.as_str()) else {
+                return err!("No file or `-r` specified");
+            };
             (Input::from_file(file_name), file_name)
         }
     };
 
     if input.is_empty() {
-        return;
+        return Ok(());
     }
 
     let lexer = Lexer::new(input.as_bytes());
@@ -124,8 +122,7 @@ fn main() {
         Ok(a) => a,
         Err(e) => {
             let lines = input.as_str().lines().collect::<Vec<&str>>();
-            e.render(input_source, &lines);
-            std::process::exit(1);
+            return err!(e.render(input_source, &lines));
         }
     };
 
@@ -146,8 +143,7 @@ fn main() {
         Ok(ir) => ir,
         Err(e) => {
             let lines = input.as_str().lines().collect::<Vec<&str>>();
-            e.render(input_source, &lines);
-            std::process::exit(1);
+            return err!(e.render(input_source, &lines));
         }
     };
 
@@ -166,8 +162,7 @@ fn main() {
     let mut cc = bc::Cc::new();
     if let Err(e) = cc.compile(&conf, &ir) {
         let lines = input.as_str().lines().collect::<Vec<&str>>();
-        e.render(input_source, &lines);
-        std::process::exit(1);
+        return err!(e.render(input_source, &lines));
     };
 
     trace!("[main] Lowered IR to bytecode");
@@ -194,7 +189,7 @@ fn main() {
     }
 
     if conf.dry {
-        return;
+        return Ok(());
     }
 
     if let Err(e) = vm.run() {
@@ -220,4 +215,11 @@ fn main() {
     }
 
     trace!("[main] Executed bytecode");
+    Ok(())
+}
+
+fn main() {
+    if let Err(e) = entry() {
+        println!("{e}")
+    }
 }

--- a/src/opt/ir.rs
+++ b/src/opt/ir.rs
@@ -167,11 +167,7 @@ pub fn tailcall(fun: &mut ir::Func) {
 
         opt_trace!(
             "ir::tailcall",
-            format!(
-                "replaced `{}` with `{}`",
-                &block.instructions.last().unwrap(),
-                &tail
-            )
+            format!("tailcalled b{}s last instruction", i)
         );
 
         *block.instructions.last_mut().unwrap() = tail;

--- a/src/opt/ir.rs
+++ b/src/opt/ir.rs
@@ -163,13 +163,53 @@ pub fn tailcall(fun: &mut ir::Func) {
             continue;
         }
 
-        let tail = Instr::Tail { dst, func, args };
-
         opt_trace!(
             "ir::tailcall",
             format!("tailcalled b{}s last instruction", i)
         );
 
-        *block.instructions.last_mut().unwrap() = tail;
+        block.instructions.pop();
+        block.term = Some(ir::Terminator::Tail { func, args });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tailcall;
+    use crate::ir::{self, Instr, Terminator, TypeId, ptype::Type};
+
+    #[test]
+    fn tailcall_rewrites_call_return_to_tail_terminator() {
+        let mut fun = ir::Func {
+            name: "tail",
+            id: ir::Id(0),
+            params: vec![ir::Id(0)],
+            ret: Some(Type::Int),
+            blocks: vec![ir::Block {
+                tombstone: false,
+                id: ir::Id(0),
+                params: vec![ir::Id(0)],
+                instructions: vec![Instr::Call {
+                    dst: TypeId {
+                        id: ir::Id(1),
+                        ty: Type::Int,
+                    },
+                    func: ir::Id(42),
+                    args: vec![ir::Id(0)],
+                }],
+                term: Some(Terminator::Return(Some(ir::Id(1)))),
+            }],
+        };
+
+        tailcall(&mut fun);
+
+        assert!(fun.blocks[0].instructions.is_empty());
+        assert!(matches!(
+            &fun.blocks[0].term,
+            Some(Terminator::Tail {
+                func,
+                args
+            }) if *func == ir::Id(42) && args == &vec![ir::Id(0)]
+        ));
     }
 }

--- a/src/opt/mod.rs
+++ b/src/opt/mod.rs
@@ -13,8 +13,6 @@ mod ir;
 mod bc;
 
 pub fn ir(ir: &mut [crate::ir::Func]) {
-    // TODO: think about making all ir optimisations block local, or is the current function local
-    // optimisation scope the better idea?
     for fun in ir {
         // so all other blocks.last() are valid
         if fun.blocks.is_empty() {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -114,7 +114,6 @@ impl<'vm> Vm<'vm> {
 
         while pc < instructions_len {
             let op = unsafe { *instructions.add(pc) };
-            crate::trace!("[vm][{:04}] {:?}", pc, op);
 
             match op {
                 Op::Nop => {}


### PR DESCRIPTION
There are some register allocation bugs this pr attempts to solve these by:

- [x] build a visualisation tool to show overlapping virtual registers
  ```text
      0  1  2  3  4  5
  v0  X  X  X  X          [0..4)
  v1  X  X  X  X          [0..4)
  v2  X                   [0..1)
  v3     X                [1..2)
  v4        X             [2..3)
  v5           X  X       [3..5)
  v6              X       [4..5)
  v7                 X    [5..6)
  ```
- [x] rework `ir::Func::live_set` from the current approach to a backwards approach
- [ ] rework `bc::regalloc::Location::Stack` to include a stack slot, this should reduce `Op::Pop` being all over the place
- [ ] rip `bc::regalloc` out 
  - [ ] move it to the root module
  - [ ] generalise `regalloc::Ralloc::new` with a `registers` param instead of hardcoding it to `vm::REGISTER_COUNT`