### PR TITLE
feat: implement macos mmap

### DIFF
--- a/purple-garden-bc/src/lib.rs
+++ b/purple-garden-bc/src/lib.rs
@@ -12,7 +12,10 @@ use purple_garden_shared::config::Config;
 
 #[derive(Debug, Clone)]
 pub enum CcFunc<'fun> {
-    Bc { name: &'fun str, pc: usize },
+    Bc {
+        name: &'fun str,
+        pc: usize,
+    },
     /// `idx` is the syscall slot the JIT page was injected at; `insns` is the
     /// emitted native instruction list, owned here and kept for `-D` (the
     /// executable bytes live only in the page).

--- a/purple-garden-jit/src/aarch64/mod.rs
+++ b/purple-garden-jit/src/aarch64/mod.rs
@@ -1,1 +1,23 @@
+use std::fmt;
 
+use purple_garden_ir as ir;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Insn {}
+
+impl Insn {
+    pub fn encode(self, _: &mut Vec<u8>) {
+        match self {}
+    }
+}
+
+impl fmt::Display for Insn {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+pub fn compile_func(_func: &ir::Func<'_>, _: &mut Vec<Insn>) -> Option<()> {
+    purple_garden_shared::trace!("[jit::aarch64] skipped: backend scaffold only");
+    None
+}

--- a/purple-garden-jit/src/lib.rs
+++ b/purple-garden-jit/src/lib.rs
@@ -9,10 +9,10 @@
 //! values stay in `Vm::r`.
 
 #[cfg(not(all(
-    target_os = "linux",
+    any(target_os = "linux", target_os = "macos"),
     any(target_arch = "x86_64", target_arch = "aarch64")
 )))]
-compile_error!("purple-garden-jit currently supports only Linux on x86_64 or aarch64");
+compile_error!("purple-garden-jit currently supports only Linux or macOS on x86_64 or aarch64");
 
 #[cfg(target_arch = "x86_64")]
 #[path = "x86/mod.rs"]
@@ -21,6 +21,7 @@ mod arch;
 #[path = "aarch64/mod.rs"]
 mod arch;
 pub mod mem;
+#[cfg(any(test, target_arch = "x86_64"))]
 mod regalloc;
 
 pub use arch::Insn;
@@ -61,7 +62,11 @@ impl Jit {
     }
 }
 
-#[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
+#[cfg(all(
+    test,
+    target_arch = "x86_64",
+    any(target_os = "linux", target_os = "macos")
+))]
 mod tests_x86 {
     use super::Jit;
     use super::mem::ExecPage;
@@ -186,5 +191,35 @@ mod tests_x86 {
         vm.bytecode = vec![Op::LoadI { dst: 0, value: 187 }, Op::Sys { idx: 0 }];
         vm.run(&syscalls).expect("vm run");
         assert_eq!(vm.r(0).as_int(), 187);
+    }
+}
+
+#[cfg(all(
+    test,
+    target_arch = "aarch64",
+    any(target_os = "linux", target_os = "macos")
+))]
+mod tests_aarch64 {
+    use super::Jit;
+    use purple_garden_ir::{Block, Func, Id, Terminator, ptype::Type};
+
+    #[test]
+    fn scaffold_falls_back_to_bytecode() {
+        let mut func = Func::new("identity", Id(0), vec![Id(0)], Some(Type::Int));
+        let params = func.intern_params(vec![Id(0)]);
+        func.blocks.push(Block {
+            tombstone: false,
+            id: Id(0),
+            instructions: vec![],
+            params,
+            term: Some(Terminator::Return {
+                value: Some(Id(0)),
+                span: 0,
+            }),
+        });
+
+        let mut jit = Jit::new();
+        assert!(jit.compile_func(&func).is_none());
+        assert!(jit.code().is_empty());
     }
 }

--- a/purple-garden-jit/src/lib.rs
+++ b/purple-garden-jit/src/lib.rs
@@ -21,7 +21,7 @@ mod arch;
 #[path = "aarch64/mod.rs"]
 mod arch;
 pub mod mem;
-#[cfg(any(test, target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 mod regalloc;
 
 pub use arch::Insn;

--- a/purple-garden-shared/src/lib.rs
+++ b/purple-garden-shared/src/lib.rs
@@ -1,10 +1,10 @@
 //! utilities used by multiple purple-garden crates.
 
 #[cfg(not(all(
-    target_os = "linux",
+    any(target_os = "linux", target_os = "macos"),
     any(target_arch = "x86_64", target_arch = "aarch64")
 )))]
-compile_error!("purple-garden-shared currently supports only Linux on x86_64 or aarch64");
+compile_error!("purple-garden-shared currently supports only Linux or macOS on x86_64 or aarch64");
 
 pub mod config;
 pub mod mmap;

--- a/purple-garden-shared/src/mmap.rs
+++ b/purple-garden-shared/src/mmap.rs
@@ -1,30 +1,51 @@
-//! copied and applied from <https://github.com/xnacly/stinkarm/blob/master/src/mem/mmap.rs>
+use std::ffi::c_void;
+use std::ptr::NonNull;
 
-#[cfg(target_arch = "x86_64")]
-const MMAP_SYSCALL: i64 = 9;
-#[cfg(target_arch = "x86_64")]
-const MPROTECT_SYSCALL: i64 = 10;
-#[cfg(target_arch = "x86_64")]
-const MUNMAP_SYSCALL: i64 = 11;
+#[cfg(target_pointer_width = "64")]
+type OffT = i64;
 
-#[cfg(target_arch = "aarch64")]
-const MMAP_SYSCALL: i64 = 222;
-#[cfg(target_arch = "aarch64")]
-const MPROTECT_SYSCALL: i64 = 226;
-#[cfg(target_arch = "aarch64")]
-const MUNMAP_SYSCALL: i64 = 215;
+unsafe extern "C" {
+    #[link_name = "mmap"]
+    fn sys_mmap(
+        addr: *mut c_void,
+        len: usize,
+        prot: i32,
+        flags: i32,
+        fd: i32,
+        offset: OffT,
+    ) -> *mut c_void;
+    #[link_name = "mprotect"]
+    fn sys_mprotect(addr: *mut c_void, len: usize, prot: i32) -> i32;
+    #[link_name = "munmap"]
+    fn sys_munmap(addr: *mut c_void, len: usize) -> i32;
+}
 
-// Not an enum, since NONE, READ, WRITE and EXEC arent mutually exclusive
+#[cfg(target_os = "linux")]
+const MAP_PRIVATE: i32 = 0x0002;
+#[cfg(target_os = "linux")]
+const MAP_ANONYMOUS: i32 = 0x0020;
+
+#[cfg(target_os = "macos")]
+const MAP_PRIVATE: i32 = 0x0002;
+#[cfg(target_os = "macos")]
+const MAP_ANONYMOUS: i32 = 0x1000;
+
+const MAP_FAILED: *mut c_void = !0usize as *mut c_void;
+
+// Not an enum, since NONE, READ, WRITE and EXEC are not mutually exclusive.
+#[derive(Clone, Copy)]
 pub struct MmapProt(i32);
+
 impl MmapProt {
-    /// no permissions
-    pub const NONE: MmapProt = MmapProt(0x00);
-    /// pages can be read
-    pub const READ: MmapProt = MmapProt(0x01);
-    /// pages can be written
-    pub const WRITE: MmapProt = MmapProt(0x02);
-    /// pages can be executed
-    pub const EXEC: MmapProt = MmapProt(0x04);
+    /// No permissions.
+    pub const NONE: Self = Self(0x00);
+    /// Pages can be read.
+    pub const READ: Self = Self(0x01);
+    /// Pages can be written.
+    pub const WRITE: Self = Self(0x02);
+    /// Pages can be executed.
+    pub const EXEC: Self = Self(0x04);
+
     #[must_use]
     pub fn bits(self) -> i32 {
         self.0
@@ -33,32 +54,20 @@ impl MmapProt {
 
 impl std::ops::BitOr for MmapProt {
     type Output = Self;
+
     fn bitor(self, rhs: Self) -> Self::Output {
-        MmapProt(self.0 | rhs.0)
+        Self(self.0 | rhs.0)
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct MmapFlags(i32);
 
 impl MmapFlags {
-    /// share changes
-    pub const SHARED: MmapFlags = MmapFlags(0x0001);
-    /// changes are private
-    pub const PRIVATE: MmapFlags = MmapFlags(0x0002);
-    /// map addr must be exactly as requested
-    pub const FIXED: MmapFlags = MmapFlags(0x0010);
-
-    // MAP_FIXED_NOREPLACE (Linux ≥ 5.4)
-    pub const NOREPLACE: MmapFlags = MmapFlags(0x0010_0000);
-
-    /// allocated from memory, swap space
-    pub const ANONYMOUS: MmapFlags = MmapFlags(0x20);
-
-    /// mapping is used for stack
-    pub const STACK: MmapFlags = MmapFlags(0x4000);
-
-    /// omit from dumps
-    pub const CONCEAL: MmapFlags = MmapFlags(0x8000);
+    /// Changes are private.
+    pub const PRIVATE: Self = Self(MAP_PRIVATE);
+    /// Allocate zero-filled memory not backed by a file.
+    pub const ANONYMOUS: Self = Self(MAP_ANONYMOUS);
 
     #[must_use]
     pub fn bits(self) -> i32 {
@@ -68,139 +77,61 @@ impl MmapFlags {
 
 impl std::ops::BitOr for MmapFlags {
     type Output = Self;
+
     fn bitor(self, rhs: Self) -> Self::Output {
-        MmapFlags(self.0 | rhs.0)
+        Self(self.0 | rhs.0)
     }
 }
 
 #[inline(always)]
 pub fn mmap(
-    ptr: Option<std::ptr::NonNull<u8>>,
+    ptr: Option<NonNull<u8>>,
     length: usize,
     prot: MmapProt,
     flags: MmapFlags,
     fd: i32,
     offset: i64,
-) -> Result<std::ptr::NonNull<u8>, String> {
-    let ret: isize;
+) -> Result<NonNull<u8>, String> {
+    let ret = unsafe {
+        sys_mmap(
+            ptr.map_or(std::ptr::null_mut(), |ptr| ptr.as_ptr().cast()),
+            length,
+            prot.bits(),
+            flags.bits(),
+            fd,
+            offset as OffT,
+        )
+    };
 
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") MMAP_SYSCALL,
-            in("rdi") ptr.map_or(std::ptr::null_mut(), std::ptr::NonNull::as_ptr),
-            in("rsi") length,
-            in("rdx") prot.bits(),
-            in("r10") flags.bits(),
-            in("r8")  fd,
-            in("r9")  offset,
-            lateout("rax") ret,
-            clobber_abi("sysv64"),
-            options(nostack)
-        );
-    }
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        let addr = ptr.map_or(0, |ptr| ptr.as_ptr() as usize);
-        core::arch::asm!(
-            "svc #0",
-            in("x8") MMAP_SYSCALL,
-            inlateout("x0") addr => ret,
-            in("x1") length,
-            in("x2") prot.bits(),
-            in("x3") flags.bits(),
-            in("x4") fd as isize,
-            in("x5") offset,
-            options(nostack)
-        );
-    }
-    if ret < 0 {
-        let errno = -ret;
-        return Err(format!(
-            "mmap failed (errno {}): {}",
-            errno,
-            std::io::Error::from_raw_os_error(errno as i32)
-        ));
+    if ret == MAP_FAILED {
+        return Err(os_error("mmap"));
     }
 
-    Ok(unsafe { std::ptr::NonNull::new_unchecked(ret as *mut u8) })
+    Ok(unsafe { NonNull::new_unchecked(ret.cast()) })
 }
 
 #[inline(always)]
-pub fn mprotect(ptr: std::ptr::NonNull<u8>, length: usize, prot: MmapProt) -> Result<(), String> {
-    let ret: isize;
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") MPROTECT_SYSCALL,
-            in("rdi") ptr.as_ptr(),
-            in("rsi") length,
-            in("rdx") prot.bits(),
-            lateout("rax") ret,
-            clobber_abi("sysv64"),
-            options(nostack)
-        );
+pub fn mprotect(ptr: NonNull<u8>, length: usize, prot: MmapProt) -> Result<(), String> {
+    if unsafe { sys_mprotect(ptr.as_ptr().cast(), length, prot.bits()) } == -1 {
+        return Err(os_error("mprotect"));
     }
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        let addr = ptr.as_ptr() as usize;
-        core::arch::asm!(
-            "svc #0",
-            in("x8") MPROTECT_SYSCALL,
-            inlateout("x0") addr => ret,
-            in("x1") length,
-            in("x2") prot.bits(),
-            options(nostack)
-        );
-    }
-    if ret < 0 {
-        let errno = -ret;
-        return Err(format!(
-            "mprotect failed (errno {}): {}",
-            errno,
-            std::io::Error::from_raw_os_error(errno as i32)
-        ));
-    }
+
     Ok(())
 }
 
 #[inline(always)]
-pub fn munmap(ptr: std::ptr::NonNull<u8>, size: usize) -> Result<(), String> {
-    let ret: isize;
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") MUNMAP_SYSCALL,
-            in("rdi") ptr.as_ptr(),
-            in("rsi") size,
-            lateout("rax") ret,
-            clobber_abi("sysv64"),
-            options(nostack)
-        );
-    }
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        let addr = ptr.as_ptr() as usize;
-        core::arch::asm!(
-            "svc #0",
-            in("x8") MUNMAP_SYSCALL,
-            inlateout("x0") addr => ret,
-            in("x1") size,
-            options(nostack)
-        );
-    }
-
-    if ret < 0 {
-        let errno = -ret;
-        return Err(format!(
-            "munmap failed (errno {}): {}",
-            errno,
-            std::io::Error::from_raw_os_error(errno as i32)
-        ));
+pub fn munmap(ptr: NonNull<u8>, size: usize) -> Result<(), String> {
+    if unsafe { sys_munmap(ptr.as_ptr().cast(), size) } == -1 {
+        return Err(os_error("munmap"));
     }
 
     Ok(())
+}
+
+fn os_error(op: &str) -> String {
+    let err = std::io::Error::last_os_error();
+    format!(
+        "{op} failed (errno {}): {err}",
+        err.raw_os_error().unwrap_or(0)
+    )
 }

--- a/purple-garden-shared/src/mmap.rs
+++ b/purple-garden-shared/src/mmap.rs
@@ -1,10 +1,12 @@
 use std::ffi::c_void;
 use std::ptr::NonNull;
 
+/// Native file-offset type used by `mmap(2)` on the supported 64-bit targets.
 #[cfg(target_pointer_width = "64")]
 type OffT = i64;
 
 unsafe extern "C" {
+    /// Maps files or anonymous pages into this process using the platform C ABI.
     #[link_name = "mmap"]
     fn sys_mmap(
         addr: *mut c_void,
@@ -14,8 +16,10 @@ unsafe extern "C" {
         fd: i32,
         offset: OffT,
     ) -> *mut c_void;
+    /// Changes page protections for an existing mapping using the platform C ABI.
     #[link_name = "mprotect"]
     fn sys_mprotect(addr: *mut c_void, len: usize, prot: i32) -> i32;
+    /// Releases a mapping created by `mmap(2)` using the platform C ABI.
     #[link_name = "munmap"]
     fn sys_munmap(addr: *mut c_void, len: usize) -> i32;
 }
@@ -32,7 +36,10 @@ const MAP_ANONYMOUS: i32 = 0x1000;
 
 const MAP_FAILED: *mut c_void = !0usize as *mut c_void;
 
-// Not an enum, since NONE, READ, WRITE and EXEC are not mutually exclusive.
+/// Page permissions passed to [`mmap`] and [`mprotect`].
+///
+/// Not an enum: `READ`, `WRITE`, and `EXEC` can be combined for mappings that
+/// need multiple permissions.
 #[derive(Clone, Copy)]
 pub struct MmapProt(i32);
 
@@ -46,6 +53,7 @@ impl MmapProt {
     /// Pages can be executed.
     pub const EXEC: Self = Self(0x04);
 
+    /// Returns the raw platform permission bits.
     #[must_use]
     pub fn bits(self) -> i32 {
         self.0
@@ -60,6 +68,7 @@ impl std::ops::BitOr for MmapProt {
     }
 }
 
+/// Mapping flags passed to [`mmap`].
 #[derive(Clone, Copy)]
 pub struct MmapFlags(i32);
 
@@ -69,6 +78,7 @@ impl MmapFlags {
     /// Allocate zero-filled memory not backed by a file.
     pub const ANONYMOUS: Self = Self(MAP_ANONYMOUS);
 
+    /// Returns the raw platform flag bits.
     #[must_use]
     pub fn bits(self) -> i32 {
         self.0
@@ -84,6 +94,12 @@ impl std::ops::BitOr for MmapFlags {
 }
 
 #[inline(always)]
+/// Creates a memory mapping and returns its non-null base address.
+///
+/// `ptr` is an optional address hint, `length` is the mapping size in bytes,
+/// `prot` controls page permissions, `flags` controls mapping behavior, and
+/// `fd`/`offset` select the mapped file region. For anonymous mappings, pass
+/// `MmapFlags::ANONYMOUS`, `fd = -1`, and `offset = 0`.
 pub fn mmap(
     ptr: Option<NonNull<u8>>,
     length: usize,
@@ -111,6 +127,7 @@ pub fn mmap(
 }
 
 #[inline(always)]
+/// Changes page permissions for an existing mapping.
 pub fn mprotect(ptr: NonNull<u8>, length: usize, prot: MmapProt) -> Result<(), String> {
     if unsafe { sys_mprotect(ptr.as_ptr().cast(), length, prot.bits()) } == -1 {
         return Err(os_error("mprotect"));
@@ -120,6 +137,7 @@ pub fn mprotect(ptr: NonNull<u8>, length: usize, prot: MmapProt) -> Result<(), S
 }
 
 #[inline(always)]
+/// Releases a memory mapping created by [`mmap`].
 pub fn munmap(ptr: NonNull<u8>, size: usize) -> Result<(), String> {
     if unsafe { sys_munmap(ptr.as_ptr().cast(), size) } == -1 {
         return Err(os_error("munmap"));
@@ -134,4 +152,55 @@ fn os_error(op: &str) -> String {
         "{op} failed (errno {}): {err}",
         err.raw_os_error().unwrap_or(0)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MmapFlags, MmapProt, mmap, mprotect, munmap};
+
+    #[test]
+    fn anonymous_mapping_is_zeroed_and_writable() {
+        let len = 4096;
+        let ptr = mmap(
+            None,
+            len,
+            MmapProt::READ | MmapProt::WRITE,
+            MmapFlags::PRIVATE | MmapFlags::ANONYMOUS,
+            -1,
+            0,
+        )
+        .expect("anonymous mmap");
+
+        let bytes = unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), len) };
+        assert!(bytes.iter().all(|byte| *byte == 0));
+
+        bytes[0] = 0xab;
+        bytes[len - 1] = 0xcd;
+        assert_eq!(bytes[0], 0xab);
+        assert_eq!(bytes[len - 1], 0xcd);
+
+        munmap(ptr, len).expect("munmap");
+    }
+
+    #[test]
+    fn mapping_permissions_can_be_changed() {
+        let len = 4096;
+        let ptr = mmap(
+            None,
+            len,
+            MmapProt::READ | MmapProt::WRITE,
+            MmapFlags::PRIVATE | MmapFlags::ANONYMOUS,
+            -1,
+            0,
+        )
+        .expect("anonymous mmap");
+
+        mprotect(ptr, len, MmapProt::READ).expect("mprotect read-only");
+        mprotect(ptr, len, MmapProt::READ | MmapProt::WRITE).expect("mprotect read-write");
+
+        unsafe { ptr.as_ptr().write(0x7f) };
+        assert_eq!(unsafe { ptr.as_ptr().read() }, 0x7f);
+
+        munmap(ptr, len).expect("munmap");
+    }
 }

--- a/purple-garden/src/lib.rs
+++ b/purple-garden/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(not(all(
-    target_os = "linux",
+    any(target_os = "linux", target_os = "macos"),
     any(target_arch = "x86_64", target_arch = "aarch64")
 )))]
-compile_error!("purple-garden currently supports only Linux on x86_64 or aarch64");
+compile_error!("purple-garden currently supports only Linux or macOS on x86_64 or aarch64");
 
 use purple_garden_bc as bc;
 use purple_garden_frontend::{err::PgError, lex, lower, parser};


### PR DESCRIPTION
This PR adds macOS as a supported platform for the shared/runtime build path without introducing new dependencies.

The Linux-only raw syscall `mmap` wrapper has been replaced with small in-tree `extern "C"` bindings to the platform C ABI for `mmap`, `mprotect`, and `munmap`. Platform-specific constants are defined locally for Linux and macOS, keeping the project dependency-free while avoiding Linux syscall numbers and Linux-only error handling.

The platform guards in `purple-garden-shared`, `purple-garden-jit`, and `purple-garden` now allow Linux or macOS on `x86_64` and `aarch64`.

For `aarch64`, the JIT backend is intentionally only a scaffold. It exposes the expected `Insn` and `compile_func` surface so the crate compiles, but `compile_func` always returns `None`. This preserves the existing bytecode fallback path and avoids pretending there is a real AArch64 native backend.

**Key Changes**
- Replaced Linux raw syscall mmap implementation with dependency-free platform C ABI bindings.
- Added macOS support to platform compile guards.
- Removed Linux-only mmap flags from the shared API surface.
- Added an AArch64 JIT scaffold that compiles but always falls back to bytecode.
- Kept x86 JIT behavior intact.
- Added/updated tests to verify AArch64 JIT fallback behavior.

**Notes**
The current AArch64 path does not emit native code. It only enables macOS/arm64 builds and execution through the bytecode fallback path.