### PR TITLE
Introduce embedding side generic functions via monomorphism

### DIFF
--- a/NRFC/generics.md
+++ b/NRFC/generics.md
@@ -1,5 +1,12 @@
 # Generics
 
+All generics, be it specialisation or monomorphisation are not
+user exposed in the sense of creating them, they can however be
+consumed by users. Embedders can mark functions as either
+specialising (choosing an implementation based on the type) or
+generic, which accepts a list of generic types used in said
+function.
+
 ## Specialisation based
 
 Things like 
@@ -71,7 +78,7 @@ globals:
   0002:    ret
 ```
 
-## Substitution based
+## Monomorphism
 
 However, this only works for known types requiring different implementations.
 It does not work for something like `cmp.or(bool,T) Option<T>`, which decided
@@ -82,3 +89,45 @@ unlimited amount of work specialising every possible T for every stdlib
 function would require. Therefore purple garden needs substitution based
 generics, which enable passing a value through something and "specialising" the
 function at compile time for the known input automatically.
+
+Given the identity function:
+
+
+<!-- TODO: figure out how to actually instruct purple garden to
+see and support generics -->
+
+```rust
+#[pg_pkg]
+mod tt {
+    fn identity<T>(x: T) -> T { x }
+}
+```
+
+For the below example usage from pgs side there should be a generated function for each of the different usages (in both IR, pgvm and x86)
+
+```garden
+import "tt"
+tt.identity(3.1415)         # Double
+tt.identity(3)              # Int
+tt.identity("hello")        # Str
+tt.identity(true)           # Bool
+tt.identity({ n:9 m:10 })   # Record<n:Int m:Int>
+tt.identity(["ab" "bc"])    # Array<Str>
+```
+
+<!-- TODO: add IR and typechecker output here -->
+
+To do so the generic type def in the function signature instructs
+the typechecker to infer types passed to the function and thus
+build the actual function signature at type check time.
+
+A more complex example:
+
+```rust
+#[pg_pkg]
+mod opt {
+}
+```
+
+
+<!-- TODO: add IR and typechecker output here -->

--- a/purple-garden-typecheck/src/lib.rs
+++ b/purple-garden-typecheck/src/lib.rs
@@ -469,6 +469,7 @@ impl<'t> Typechecker<'t> {
                 let (first_type, mut poisoned) = match self.node(*first_member) {
                     TcType::Known(ty) => (ty, false),
                     TcType::Poison => (Type::Void, true),
+                    _ => unreachable!(),
                 };
 
                 for member in members.iter().skip(1) {
@@ -498,6 +499,8 @@ impl<'t> Typechecker<'t> {
                         TcType::Poison => {
                             poisoned = true;
                         }
+
+                        _ => unreachable!(),
                     }
                 }
 
@@ -526,6 +529,7 @@ impl<'t> Typechecker<'t> {
                         TcType::Poison => {
                             poisoned = true;
                         }
+                        _ => unreachable!(),
                     }
                 }
 
@@ -722,6 +726,7 @@ impl<'t> Typechecker<'t> {
                         ));
                         TcType::Poison
                     }
+                    TcType::Variable(_) => unreachable!(),
                     _ => TcType::Poison,
                 }
             }
@@ -750,6 +755,8 @@ impl<'t> Typechecker<'t> {
                         else {
                             unreachable!();
                         };
+
+                        // TODO: add type variable as valid argument type here
 
                         // Type args up front: overload selection reads them back
                         // by reference, and `node` memoises so the single-candidate

--- a/purple-garden-typecheck/src/typedefs.rs
+++ b/purple-garden-typecheck/src/typedefs.rs
@@ -19,13 +19,16 @@ pub struct TypecheckOutput<'t> {
 
 /// Internal typechecking result for one AST node.
 ///
-/// `Known` means later nodes can safely use the type. `Poison` means the node
-/// already produced, or depends on, an error and should not cause cascading
-/// follow-up diagnostics. We keep this separate from `purple_garden_ir::Type`
+/// `Known` means later nodes can safely use the type. `Poison` means the node already produced, or
+/// depends on, an error and should not cause cascading follow-up diagnostics. `Variable` enables
+/// monomorphism based generic embedding side generics.
+///
+/// We keep this separate from `purple_garden_ir::Type`
 /// so the IR/runtime type vocabulary does not need an error sentinel.
 #[derive(Debug, Clone)]
 pub(super) enum TcType<'t> {
     Known(Type<'t>),
+    Variable(char),
     Poison,
 }
 
@@ -33,14 +36,14 @@ impl<'t> TcType<'t> {
     pub(super) fn known(self) -> Option<Type<'t>> {
         match self {
             Self::Known(ty) => Some(ty),
-            Self::Poison => None,
+            Self::Poison | Self::Variable(_) => None,
         }
     }
 
     pub(super) fn as_known(&self) -> Option<&Type<'t>> {
         match self {
             Self::Known(ty) => Some(ty),
-            Self::Poison => None,
+            Self::Poison | Self::Variable(_) => None,
         }
     }
 }


### PR DESCRIPTION
The main idea is to support the identity function:

```rust
#[pg_pkg]
mod tt {
 fn identity<T: IntoValue+FromValue>(x: T) -> T { x }
}
```

For the below example usage from pgs side there should be a generated function for each of the different usages (in both IR, pgvm and x86)

```garden
import "tt"
tt.identity(3.1415)         # Double
tt.identity(3)              # Int
tt.identity("hello")        # Str
tt.identity(true)           # Bool
tt.identity({ n:9 m:10 })   # Record<n:Int m:Int>
tt.identity(["ab" "bc"])    # Array<Str>
```

