### PR TITLE
runtime: complete fixed-frame reset and dispatch migration

### DIFF
--- a/purple-garden-cli/src/main.rs
+++ b/purple-garden-cli/src/main.rs
@@ -257,7 +257,11 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
         vm.take_trap().map_or(Ok(()), Err)
     } else {
         vm.pc = entry;
-        vm.run(&syscalls)
+        if conf.backtrace {
+            vm.run::<true>(&syscalls)
+        } else {
+            vm.run::<false>(&syscalls)
+        }
     };
 
     if let Err(e) = run {

--- a/purple-garden-runtime/src/vm.rs
+++ b/purple-garden-runtime/src/vm.rs
@@ -120,7 +120,7 @@ impl Vm {
     pub fn new(config: VmConfig) -> Self {
         let mut frames = vec![CallFrame::default(); frames_in(config.stack_size).saturating_add(1)]
             .into_boxed_slice();
-        frames[0] = Self::root_frame()
+        frames[0] = Self::root_frame();
 
         let collect = if config.no_gc {
             Self::collect_noop
@@ -166,8 +166,8 @@ impl Vm {
         #[cfg(debug_assertions)]
         self.r.fill(Value(0xDEAD_AFFE_DEAD_AFFE));
         self.pc = ROOT_RETURN_ADDR;
-        self.frames.clear();
-        self.frames.push(Self::root_frame());
+        self.frames[0] = Self::root_frame();
+        self.frame_depth = 1;
         self.spilled.clear();
         self.backtrace.clear();
         self.pending_trap = None;
@@ -629,12 +629,14 @@ mod ops {
 
         vm.reset();
         vm.pc = 0;
-        vm.run(&[]).expect("first invocation should succeed");
+        vm.run::<false>(&[])
+            .expect("first invocation should succeed");
         assert_eq!(vm.r(0).as_int(), 42);
 
         vm.reset();
         vm.pc = 0;
-        vm.run(&[]).expect("second invocation should succeed");
+        vm.run::<false>(&[])
+            .expect("second invocation should succeed");
         assert_eq!(vm.r(0).as_int(), 42);
     }
 
@@ -654,12 +656,16 @@ mod ops {
 
         vm.reset();
         vm.pc = 0;
-        assert!(matches!(vm.run(&[]), Err(Anomaly::DivisionByZero { .. })));
+        assert!(matches!(
+            vm.run::<false>(&[]),
+            Err(Anomaly::DivisionByZero { .. })
+        ));
 
         vm.bytecode[2] = Op::LoadI { dst: 0, value: 7 };
         vm.reset();
         vm.pc = 0;
-        vm.run(&[]).expect("invocation after a trap should succeed");
+        vm.run::<false>(&[])
+            .expect("invocation after a trap should succeed");
         assert_eq!(vm.r(0).as_int(), 7);
     }
 

--- a/purple-garden/src/lib.rs
+++ b/purple-garden/src/lib.rs
@@ -425,7 +425,11 @@ impl<'p> Program<'p> {
         match function.handle {
             CcCallTarget::Bc { pc } => {
                 self.vm.pc = pc;
-                self.vm.run(&self.syscalls)?;
+                if self.vm.config.backtrace {
+                    self.vm.run::<true>(&self.syscalls)?;
+                } else {
+                    self.vm.run::<false>(&self.syscalls)?;
+                }
             }
             CcCallTarget::Native { idx } => {
                 unsafe { self.syscalls[idx as usize]((&mut self.vm as *mut Vm).cast()) };
@@ -630,7 +634,8 @@ mod tests {
 
     #[test]
     fn compile_collects_signatures_for_bytecode_and_native_targets() {
-        for (no_jit, want_native) in [(true, false), (false, true)] {
+        for no_jit in [true, false] {
+            let want_native = !no_jit && cfg!(target_arch = "x86_64");
             let mut config = config::Config::default();
             config.no_jit = no_jit;
             let program = Pg::new()


### PR DESCRIPTION
## Summary

Complete the VM fixed-frame migration by restoring root-frame reinstallation and frame-depth reset after execution.

Select `Vm::run` backtrace specialization at each remaining direct entry point, and make native-target coverage account for the intentional aarch64 bytecode fallback.

This is the runtime baseline required by the following typed function-handle API PR.

## Validation

- `cargo fmt --check`
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`
- `cargo test --workspace --all-features --locked`
- `cargo run -p embed-fn-dispatch --locked`