### PR TITLE
Vendoring useful packages into the std vendor prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "purple-garden-shared",
  "purple-garden-std",
  "purple-garden-typecheck",
+ "purple-garden-vendor",
  "serde",
  "serde_json",
 ]
@@ -676,6 +677,14 @@ dependencies = [
  "purple-garden-runtime",
  "purple-garden-shared",
  "purple-garden-std",
+]
+
+[[package]]
+name = "purple-garden-vendor"
+version = "0.1.0"
+dependencies = [
+ "purple-garden-macros",
+ "purple-garden-runtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["purple-garden", "purple-garden-cli", "purple-garden-ir", "purple-garden-jit", "purple-garden-macros", "purple-garden-runtime", "purple-garden-std", "purple-garden-opt", "purple-garden-bc", "purple-garden-frontend", "purple-garden-typecheck", "purple-garden-shared", "examples/embed-fn-dispatch"]
+members = ["purple-garden", "purple-garden-cli", "purple-garden-ir", "purple-garden-jit", "purple-garden-macros", "purple-garden-runtime", "purple-garden-std", "purple-garden-vendor", "purple-garden-opt", "purple-garden-bc", "purple-garden-frontend", "purple-garden-typecheck", "purple-garden-shared", "examples/embed-fn-dispatch"]
 default-members = ["purple-garden-cli"]
 resolver = "3"
 

--- a/examples/embed-fn-dispatch/src/main.rs
+++ b/examples/embed-fn-dispatch/src/main.rs
@@ -16,21 +16,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let identity_function = pg
-        .function("identity")
+        .function::<(i64,), i64>("identity")
         .expect("Wasnt able to find `identity` function");
 
     assert_eq!(
+        // unsafe call, this does no signature validation and no argument count match check
         unsafe { pg.call_unchecked(&identity_function, &[256i64.into(),])? },
         256i64.into()
     );
 
     let dispatch_function = pg
-        .function("dispatch")
+        .function::<(i64,), ()>("dispatch")
         .expect("Wasnt able to find `dispatch` function");
 
     for i in 0..=16 {
         // prints numbers 0..=16 using purple gardens io.println
-        pg.call::<_, ()>(&dispatch_function, (i,))?;
+        pg.call(&dispatch_function, (i,))?;
     }
 
     Ok(())

--- a/examples/vendor/raylib.garden
+++ b/examples/vendor/raylib.garden
@@ -1,0 +1,35 @@
+import (
+    "vendor/exp/raylib"
+)
+
+let width = 1024
+let height = 512
+
+#! create a raylib color from a rgb input
+fn color(r:Int g:Int b:Int) Record<r:Int g:Int b:Int a:Int> {
+  {r: r g: g b: b a: 255}
+}
+
+#! render a single frame
+fn frame(width: Int height: Int) Void {
+    raylib.begin_drawing()
+    raylib.clear_background(color(30 30 30))
+    let font_size = 64
+    let text_width = raylib.measure_text("purple-garden" font_size)
+    raylib.draw_text("purple-garden" (width - text_width) / 2 height/2 font_size color(0 188 212))
+    raylib.end_drawing()
+}
+
+fn render(width: Int height: Int) Void {
+  match {
+      raylib.should_close() { raylib.close() }
+      {
+        frame(width height)
+        render(width height)
+      }
+  }
+}
+
+raylib.init(width height "Hello from raylib in purple garden")
+raylib.set_target_fps(240)
+render(width height)

--- a/purple-garden-cli/Cargo.toml
+++ b/purple-garden-cli/Cargo.toml
@@ -34,6 +34,7 @@ purple-garden-ir = { path = "../purple-garden-ir" }
 purple-garden-jit = { path = "../purple-garden-jit" }
 purple-garden-runtime = { path = "../purple-garden-runtime" }
 purple-garden-std = { path = "../purple-garden-std" }
+purple-garden-vendor = { path = "../purple-garden-vendor" }
 purple-garden-opt = { path = "../purple-garden-opt" }
 purple-garden-bc = { path = "../purple-garden-bc" }
 purple-garden-frontend = { path = "../purple-garden-frontend" }

--- a/purple-garden-cli/src/doc.rs
+++ b/purple-garden-cli/src/doc.rs
@@ -1,4 +1,8 @@
-use purple_garden_std::{self as pstd, Pkg};
+use purple_garden_std::Pkg;
+
+pub(crate) fn resolve_pkg(query: &str) -> Option<&'static Pkg> {
+    purple_garden_std::resolve_pkg_in(crate::all_packages(), query)
+}
 
 #[must_use]
 pub(crate) fn command(query: &str) -> String {
@@ -35,7 +39,7 @@ pub(crate) fn render_query(query: Option<&str>) -> Result<String, String> {
         None => (query, None),
     };
 
-    let Some(pkg) = pstd::resolve_pkg(path) else {
+    let Some(pkg) = resolve_pkg(path) else {
         return Err(format!("query {path} couldnt be resolved to anything"));
     };
 
@@ -63,7 +67,7 @@ pub(crate) fn render_function(name: &str, variants: &[&purple_garden_runtime::Fn
 
 fn render_index() -> String {
     let mut out = String::from("Purple Garden documentation\n\nPackages:\n");
-    for pkg in purple_garden_std::STD {
+    for pkg in crate::all_packages() {
         render_pkg_index(pkg, None, &mut out);
     }
 

--- a/purple-garden-cli/src/frontend.rs
+++ b/purple-garden-cli/src/frontend.rs
@@ -50,7 +50,7 @@ pub(crate) fn analyze_path<R>(
     source_path: &Path,
     source: &[u8],
     libs: Vec<&Pkg>,
-    stdlib: &'static [Pkg],
+    stdlib: &[Pkg],
     f: impl for<'a> FnOnce(FrontendAnalysis<'a, '_>) -> R,
 ) -> R {
     let source = source_with_extern(source_path, source);

--- a/purple-garden-cli/src/lsp/analysis.rs
+++ b/purple-garden-cli/src/lsp/analysis.rs
@@ -77,24 +77,15 @@ impl DocumentState {
         super::hover::collect_lexical_hovers(&text, &mut analysis);
 
         if let Some(path) = path.as_deref() {
-            crate::frontend::analyze_path(
-                path,
-                text.as_bytes(),
-                Vec::new(),
-                purple_garden_std::STD,
-                |frontend| {
-                    super::collect::collect_frontend_analysis(frontend, &mut analysis);
-                },
-            );
+            let stdlib = crate::all_packages();
+            crate::frontend::analyze_path(path, text.as_bytes(), Vec::new(), &stdlib, |frontend| {
+                super::collect::collect_frontend_analysis(frontend, &mut analysis);
+            });
         } else {
-            crate::frontend::analyze(
-                text.as_bytes(),
-                Vec::new(),
-                purple_garden_std::STD,
-                |frontend| {
-                    super::collect::collect_frontend_analysis(frontend, &mut analysis);
-                },
-            );
+            let stdlib = crate::all_packages();
+            crate::frontend::analyze(text.as_bytes(), Vec::new(), &stdlib, |frontend| {
+                super::collect::collect_frontend_analysis(frontend, &mut analysis);
+            });
         }
 
         Self { text, analysis }

--- a/purple-garden-cli/src/lsp/completion.rs
+++ b/purple-garden-cli/src/lsp/completion.rs
@@ -205,7 +205,10 @@ fn package_member_items(
     offset: usize,
 ) -> Option<Vec<CompletionItem>> {
     let (pkg_name, prefix) = member_access_at(source, offset)?;
-    if pkg_name.is_empty() || !imported_packages.iter().any(|pkg| pkg == pkg_name) {
+    let imported_path = imported_packages
+        .iter()
+        .find(|pkg| *pkg == pkg_name || pkg.rsplit('/').next() == Some(pkg_name));
+    if pkg_name.is_empty() || imported_path.is_none() {
         return None;
     }
 
@@ -226,7 +229,7 @@ fn package_member_items(
         return Some(sorted_completion_items(items));
     }
 
-    let pkg = purple_garden_std::resolve_pkg(pkg_name)?;
+    let pkg = crate::doc::resolve_pkg(imported_path?)?;
     let items = pkg
         .overload_groups()
         .into_iter()
@@ -329,7 +332,7 @@ fn build_global_completions() -> Vec<CompletionEntry> {
             scope: CompletionScope::Global,
         });
     }
-    for pkg in purple_garden_std::STD {
+    for pkg in crate::all_packages() {
         collect_pkg_completions(pkg, None, &mut completions);
     }
     completions
@@ -339,7 +342,7 @@ fn package_entries() -> &'static [CompletionEntry] {
     static PACKAGES: OnceLock<Vec<CompletionEntry>> = OnceLock::new();
     PACKAGES.get_or_init(|| {
         let mut completions = Vec::new();
-        for pkg in purple_garden_std::STD {
+        for pkg in crate::all_packages() {
             collect_package_entries(pkg, None, &mut completions);
         }
         completions
@@ -519,6 +522,32 @@ mod tests {
             items.into_iter().map(|item| item.label).collect::<Vec<_>>(),
             vec!["age", "name"]
         );
+    }
+
+    #[test]
+    fn completes_vendor_package_paths() {
+        let items = items_at(
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+            "import \"vendor/exp/r",
+            "import \"vendor/exp/r".len(),
+        );
+        assert!(items.iter().any(|item| item.label == "vendor/exp/raylib"));
+    }
+
+    #[test]
+    fn completes_vendor_package_functions_through_leaf_import() {
+        let items = items_at(
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &["vendor/exp/raylib".to_owned()],
+            "raylib.draw_",
+            "raylib.draw_".len(),
+        );
+        assert!(items.iter().any(|item| item.label == "draw_rectangle"));
     }
 
     #[test]

--- a/purple-garden-cli/src/lsp/hover.rs
+++ b/purple-garden-cli/src/lsp/hover.rs
@@ -218,12 +218,13 @@ fn function_hover(pkg_name: &str, fn_name: &str, analysis: &DocumentAnalysis) ->
         return Some(contents.clone());
     }
 
-    let pkg = purple_garden_std::resolve_pkg(pkg_name)?;
+    let pkg_path = imported_package_path(pkg_name, analysis);
+    let pkg = crate::doc::resolve_pkg(pkg_path)?;
     let (_, variants) = pkg
         .overload_groups()
         .into_iter()
         .find(|(name, _)| *name == fn_name)?;
-    Some(overload_detail(&format!("{pkg_name}.{fn_name}"), &variants))
+    Some(overload_detail(&format!("{pkg_path}.{fn_name}"), &variants))
 }
 
 pub(super) fn import_hover(pkg: &Token<'_>, analysis: &DocumentAnalysis) -> Option<String> {
@@ -250,13 +251,38 @@ fn package_hover(pkg_name: &str, analysis: &DocumentAnalysis) -> Option<String> 
         ));
     }
 
-    let pkg = purple_garden_std::resolve_pkg(pkg_name)?;
-    let header = format!("import \"{pkg_name}\"");
-    let command = crate::doc::command(pkg_name);
+    let pkg_path = imported_package_path(pkg_name, analysis);
+    let pkg = crate::doc::resolve_pkg(pkg_path)?;
+    let header = format!("import \"{pkg_path}\"");
+    let command = crate::doc::command(pkg_path);
     if pkg.doc.is_empty() {
         Some(format!("{header}\n\n{command}"))
     } else {
         Some(format!("{header}\n\n{}\n\n{command}", pkg.doc))
+    }
+}
+
+fn imported_package_path<'a>(pkg_name: &'a str, analysis: &'a DocumentAnalysis) -> &'a str {
+    analysis
+        .imported_packages
+        .iter()
+        .find(|path| path.rsplit('/').next() == Some(pkg_name))
+        .map_or(pkg_name, String::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hovers_vendor_functions_through_their_import_alias() {
+        let mut analysis = DocumentAnalysis::default();
+        analysis.add_imported_package("vendor/exp/raylib");
+
+        let hover = function_hover("raylib", "draw_text", &analysis).unwrap();
+
+        assert!(hover.contains("fn draw_text"));
+        assert!(hover.contains("vendor/exp/raylib.draw_text"));
     }
 }
 

--- a/purple-garden-cli/src/main.rs
+++ b/purple-garden-cli/src/main.rs
@@ -8,7 +8,7 @@ use purple_garden_frontend::{
 use purple_garden_runtime::{Vm, VmConfig};
 use purple_garden_typecheck::Typechecker;
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, sync::OnceLock};
 
 mod cli;
 mod doc;
@@ -95,7 +95,8 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
         match &cmd {
             Command::Check { target } => {
                 let input = Input::from_file(target)?;
-                check_frontend(target, &input, stdlib_packages(&cli))?;
+                let stdlib = stdlib_packages(&cli);
+                check_frontend(target, &input, &stdlib)?;
                 std::process::exit(0);
             }
             Command::Intro { topic } => {
@@ -154,9 +155,10 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let libs = Vec::new();
+    let stdlib = stdlib_packages(&cli);
     let typecheck = Typechecker::new(&ast)
         .with_libs(libs.clone())
-        .with_stdlib(stdlib_packages(&cli))
+        .with_stdlib(&stdlib)
         .check();
     let has_type_errors = !typecheck.diagnostics.is_empty();
 
@@ -180,9 +182,7 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
-    let lower = Lower::new()
-        .with_libs(libs)
-        .with_stdlib(stdlib_packages(&cli));
+    let lower = Lower::new().with_libs(libs).with_stdlib(&stdlib);
     let mut ir = match lower.ir_from_types(&ast, typecheck.types) {
         Ok(v) => v,
         Err(e) => {
@@ -297,7 +297,7 @@ fn entry() -> Result<(), Box<dyn std::error::Error>> {
 fn check_frontend(
     input_source: &str,
     input: &Input,
-    stdlib: &'static [purple_garden_runtime::Pkg],
+    stdlib: &[purple_garden_runtime::Pkg],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let source_path = Path::new(input_source);
     let failed = frontend::analyze_path(
@@ -321,16 +321,28 @@ fn check_frontend(
     Ok(())
 }
 
-fn stdlib_packages(cli: &Cli) -> &'static [purple_garden_runtime::Pkg] {
+fn stdlib_packages(cli: &Cli) -> Vec<purple_garden_runtime::Pkg> {
     if cli.no_std {
-        return &[];
+        return Vec::new();
     }
 
-    if cli.no_unsafe {
-        purple_garden_std::SAFE_STD
+    let packages = if cli.no_unsafe {
+        purple_garden_std::SAFE_STD.to_vec()
     } else {
-        purple_garden_std::STD
-    }
+        return all_packages().to_vec();
+    };
+    packages
+}
+
+pub(crate) fn all_packages() -> &'static [purple_garden_runtime::Pkg] {
+    static PACKAGES: OnceLock<Vec<purple_garden_runtime::Pkg>> = OnceLock::new();
+    PACKAGES
+        .get_or_init(|| {
+            let mut packages = purple_garden_std::STD.to_vec();
+            packages.extend_from_slice(purple_garden_vendor::PACKAGES);
+            packages
+        })
+        .as_slice()
 }
 
 fn print_standalone_extern_diagnostic(input_source: &str, source: &[u8]) {

--- a/purple-garden-jit/src/x86/mod.rs
+++ b/purple-garden-jit/src/x86/mod.rs
@@ -762,7 +762,7 @@ fn validate_supported(func: &ir::Func<'_>) -> Option<SupportPlan> {
 
         for instr in &block.instructions {
             match instr {
-                ir::Instr::Noop => {}
+                ir::Instr::Noop | ir::Instr::Alloc { .. } => {}
                 ir::Instr::LoadConst { value, .. } if supported_const(value) => {}
                 ir::Instr::BinImm { op, imm, .. } if supported_bin_imm(*op) => {
                     if matches!(op, BinOp::IDiv if *imm != 0)

--- a/purple-garden-runtime/src/lib.rs
+++ b/purple-garden-runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub mod embed {
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pkg {
     pub name: &'static str,
     pub doc: &'static str,

--- a/purple-garden-std/src/lib.rs
+++ b/purple-garden-std/src/lib.rs
@@ -27,7 +27,7 @@ mod r#unsafe;
 /// `resolve_pkg` searches for a package in the standard library by its name, for instance "io/fs",
 /// "runtime/gc" or "encoding/json"
 #[must_use]
-pub fn resolve_pkg(query: &str) -> Option<&Pkg> {
+pub fn resolve_pkg(query: &str) -> Option<&'static Pkg> {
     std_pkg_index().get(query).copied()
 }
 

--- a/purple-garden-vendor/Cargo.toml
+++ b/purple-garden-vendor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "purple-garden-vendor"
+version = "0.1.0"
+edition = "2024"
+description = "Optional dependency-backed packages for Purple Garden"
+build = "build.rs"
+
+[dependencies]
+purple-garden-macros = { path = "../purple-garden-macros" }
+purple-garden-runtime = { path = "../purple-garden-runtime" }
+

--- a/purple-garden-vendor/build.rs
+++ b/purple-garden-vendor/build.rs
@@ -1,0 +1,27 @@
+fn main() {
+    // raylib is supplied by the host system.  Keeping this link in the vendor
+    // crate means the core interpreter and std crate remain raylib-independent.
+    println!("cargo:rerun-if-env-changed=RAYLIB_LIB_DIR");
+    if let Ok(dir) = std::env::var("RAYLIB_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={dir}");
+    }
+    let mut probe = std::process::Command::new("pkg-config");
+    probe.args(["--libs", "raylib"]);
+    if let Ok(output) = probe.output().and_then(|output| {
+        if output.status.success() {
+            Ok(output)
+        } else {
+            Err(std::io::Error::other("pkg-config failed"))
+        }
+    }) {
+        for flag in String::from_utf8_lossy(&output.stdout).split_whitespace() {
+            if let Some(path) = flag.strip_prefix("-L") {
+                println!("cargo:rustc-link-search=native={path}");
+            } else if let Some(lib) = flag.strip_prefix("-l") {
+                println!("cargo:rustc-link-lib={lib}");
+            }
+        }
+    } else {
+        println!("cargo:rustc-link-lib=raylib");
+    }
+}

--- a/purple-garden-vendor/flake.lock
+++ b/purple-garden-vendor/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/purple-garden-vendor/flake.nix
+++ b/purple-garden-vendor/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Development environment for Purple Garden vendor packages";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in {
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = [ pkgs.pkg-config pkgs.raylib ];
+          PKG_CONFIG_PATH = "${pkgs.raylib}/lib/pkgconfig";
+        };
+      });
+    };
+}

--- a/purple-garden-vendor/src/lib.rs
+++ b/purple-garden-vendor/src/lib.rs
@@ -1,0 +1,36 @@
+extern crate self as purple_garden;
+
+pub use purple_garden_runtime::{
+    Field, Fn, FromVm, IntoVm, PgType, Pkg, RecordFields, Type, Value, Vm,
+};
+
+#[doc(hidden)]
+pub mod embed {
+    pub use super::{Field, Fn, FromVm, IntoVm, PgType, Pkg, RecordFields, Type, Value, Vm};
+    pub use purple_garden_runtime::{
+        alloc_record, copy_record, decode_record_field, encode_record_field,
+    };
+}
+
+mod meta;
+mod raylib;
+
+pub use meta::META_PACKAGE;
+pub use raylib::RAYLIB_PACKAGE;
+
+const EXP_PACKAGE: Pkg = Pkg {
+    name: "exp",
+    doc: "Experimental dependency-backed packages.",
+    pkgs: &[RAYLIB_PACKAGE],
+    fns: &[],
+};
+
+pub const PACKAGE: Pkg = Pkg {
+    name: "vendor",
+    doc: "Dependency-backed and experimental packages.",
+    pkgs: &[EXP_PACKAGE, META_PACKAGE],
+    fns: &[],
+};
+
+/// Packages provided by optional, dependency-backed integrations.
+pub static PACKAGES: &[Pkg] = &[PACKAGE];

--- a/purple-garden-vendor/src/meta.rs
+++ b/purple-garden-vendor/src/meta.rs
@@ -1,0 +1,23 @@
+use purple_garden_macros::GardenValue;
+use purple_garden_runtime::Pkg;
+
+#[derive(GardenValue)]
+pub struct Versions {
+    pub raylib: String,
+}
+
+#[purple_garden_macros::pg_pkg(runtime = purple_garden_runtime)]
+/// Metadata for dependency-backed vendor packages.
+pub mod meta {
+    use super::Versions;
+
+    /// Returns the versions of the linked vendor dependencies.
+    #[purple_garden_macros::pg_fn(pure)]
+    pub fn versions() -> Versions {
+        Versions {
+            raylib: "6.0".to_owned(),
+        }
+    }
+}
+
+pub const META_PACKAGE: Pkg = meta::PACKAGE;

--- a/purple-garden-vendor/src/raylib.rs
+++ b/purple-garden-vendor/src/raylib.rs
@@ -1,0 +1,123 @@
+use std::ffi::CString;
+
+use purple_garden_macros::{GardenValue, pg_pkg};
+use purple_garden_runtime::{Pkg, Vm};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CColor {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+
+#[derive(GardenValue)]
+pub struct Color {
+    pub r: i64,
+    pub g: i64,
+    pub b: i64,
+    pub a: i64,
+}
+
+impl From<Color> for CColor {
+    fn from(c: Color) -> Self {
+        Self {
+            r: c.r as u8,
+            g: c.g as u8,
+            b: c.b as u8,
+            a: c.a as u8,
+        }
+    }
+}
+
+unsafe extern "C" {
+    fn InitWindow(width: i32, height: i32, title: *const std::ffi::c_char);
+    fn CloseWindow();
+    fn WindowShouldClose() -> bool;
+    fn SetTargetFPS(fps: i32);
+    fn BeginDrawing();
+    fn EndDrawing();
+    fn ClearBackground(color: CColor);
+    fn DrawText(
+        text: *const std::ffi::c_char,
+        pos_x: i32,
+        pos_y: i32,
+        font_size: i32,
+        color: CColor,
+    );
+    fn MeasureText(text: *const std::ffi::c_char, font_size: i32) -> i32;
+    fn DrawRectangle(pos_x: i32, pos_y: i32, width: i32, height: i32, color: CColor);
+}
+
+#[pg_pkg(runtime = purple_garden_runtime)]
+/// A small experimental raylib integration.
+pub mod raylib {
+    use super::*;
+
+    #[pg_fn(unsafe)]
+    pub fn init(vm: &mut Vm, width: i64, height: i64, title: String) {
+        let title = CString::new(title).unwrap_or_else(|_| CString::new("raylib").unwrap());
+        unsafe { InitWindow(width as i32, height as i32, title.as_ptr()) };
+        let _ = vm;
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn close(_: &mut Vm) {
+        unsafe { CloseWindow() };
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn should_close(_: &mut Vm) -> bool {
+        unsafe { WindowShouldClose() }
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn set_target_fps(_: &mut Vm, fps: i64) {
+        unsafe { SetTargetFPS(fps as i32) };
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn begin_drawing(_: &mut Vm) {
+        unsafe { BeginDrawing() };
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn end_drawing(_: &mut Vm) {
+        unsafe { EndDrawing() };
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn clear_background(_: &mut Vm, color: Color) {
+        unsafe { ClearBackground(color.into()) };
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn draw_text(_: &mut Vm, text: String, x: i64, y: i64, size: i64, color: Color) {
+        let text = CString::new(text).unwrap_or_default();
+        unsafe { DrawText(text.as_ptr(), x as i32, y as i32, size as i32, color.into()) };
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn measure_text(_: &mut Vm, text: String, size: i64) -> i64 {
+        let text = CString::new(text).unwrap_or_default();
+        unsafe { MeasureText(text.as_ptr(), size as i32) as i64 }
+    }
+
+    #[pg_fn(unsafe)]
+    pub fn draw_rectangle(_: &mut Vm, x: i64, y: i64, width: i64, height: i64, color: Color) {
+        unsafe {
+            DrawRectangle(
+                x as i32,
+                y as i32,
+                width as i32,
+                height as i32,
+                color.into(),
+            )
+        };
+    }
+
+    pub use super::Color;
+}
+
+pub const RAYLIB_PACKAGE: Pkg = raylib::PACKAGE;

--- a/purple-garden/src/lib.rs
+++ b/purple-garden/src/lib.rs
@@ -8,7 +8,7 @@
 )))]
 compile_error!("purple-garden currently supports only Linux or macOS on x86_64 or aarch64");
 
-use std::collections::HashMap;
+use std::{collections::HashMap, marker::PhantomData};
 
 use purple_garden_bc::{self as bc, CcCallTarget};
 use purple_garden_frontend::{
@@ -250,12 +250,108 @@ pub struct Program<'p> {
     funcs: HashMap<&'p str, (CcCallTarget, FunctionType<'p>)>,
 }
 
-/// A handle to a purple garden function extracted from [`Program`] via [`Program::function`],
-/// invokable using [`Program::call`] or [`Program::call_unchecked`]
+/// A typed handle to a purple garden function extracted from [`Program`] via
+/// [`Program::function`].
+///
+/// `Args` and `Ret` are the Rust types expected when invoking this function.
+/// [`Program::call`] verifies that they match the Garden declaration before
+/// executing it.
 #[derive(Debug)]
-pub struct Function<'f> {
+pub struct Function<'f, Args, Ret> {
     handle: CcCallTarget,
     signature: FunctionType<'f>,
+    types: PhantomData<fn(Args) -> Ret>,
+}
+
+/// Error returned by [`Program::call`].
+///
+/// Signature variants describe a mismatch between the Rust types selected on
+/// [`Program::function`] and the Garden function declaration. [`CallError::Runtime`]
+/// contains a trap raised while the function was executing.
+#[derive(Debug)]
+pub enum CallError {
+    /// The requested Rust return type does not match the Garden return type.
+    ReturnType { expected: String, actual: String },
+    /// The requested Rust argument count does not match the Garden declaration.
+    ArgumentCount { expected: usize, actual: usize },
+    /// One requested Rust argument type does not match the Garden declaration.
+    ArgumentType {
+        index: usize,
+        expected: String,
+        actual: String,
+    },
+    /// Execution trapped in the Garden VM.
+    Runtime(Anomaly),
+}
+
+impl std::fmt::Display for CallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReturnType { expected, actual } => {
+                write!(f, "return type mismatch: expected {expected}, got {actual}")
+            }
+            Self::ArgumentCount { expected, actual } => {
+                write!(
+                    f,
+                    "argument count mismatch: expected {expected}, got {actual}"
+                )
+            }
+            Self::ArgumentType {
+                index,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "argument type mismatch at index {index}: expected {expected}, got {actual}"
+            ),
+            Self::Runtime(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for CallError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Runtime(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl<Args, Ret> Function<'_, Args, Ret>
+where
+    Args: CallArgs,
+    Ret: PgType,
+{
+    fn verify_signature(&self) -> Result<(), CallError> {
+        if Ret::TYPE != self.signature.ret {
+            return Err(CallError::ReturnType {
+                expected: self.signature.ret.to_string(),
+                actual: Ret::TYPE.to_string(),
+            });
+        }
+
+        let as_types = Args::TYPES;
+        if as_types.len() != self.signature.args.len() {
+            return Err(CallError::ArgumentCount {
+                expected: self.signature.args.len(),
+                actual: as_types.len(),
+            });
+        }
+
+        for (i, arg) in as_types.iter().enumerate() {
+            let expected_type = &self.signature.args[i].1;
+            if arg != expected_type {
+                return Err(CallError::ArgumentType {
+                    index: i,
+                    expected: expected_type.to_string(),
+                    actual: arg.to_string(),
+                });
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<'p> Program<'p> {
@@ -345,10 +441,10 @@ impl<'p> Program<'p> {
     ///
     /// let mut program = Pg::new()
     ///     .compile(br#"fn identity(value: Int) Int { value }"#)?;
-    /// let identity = program.function("identity").expect("function exists");
-    /// assert_eq!(program.call::<_, i64>(&identity, (42i64,))?, 42);
+    /// let identity = program.function::<_, i64>("identity").expect("function exists");
+    /// assert_eq!(program.call(&identity, (42i64,))?, 42);
     ///
-    /// assert!(program.function("not_declared").is_none());
+    /// assert!(program.function::<(i64,), i64>("not_declared").is_none());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
@@ -358,16 +454,20 @@ impl<'p> Program<'p> {
     /// use purple_garden::Pg;
     ///
     /// let mut program = Pg::new().compile(br#"fn double(value: Int) Int { value * 2 }"#)?;
-    /// let double = program.function("double").expect("function exists");
+    /// let double = program.function::<_, i64>("double").expect("function exists");
     /// for i in 0..4i64 {
-    ///     assert_eq!(program.call::<_, i64>(&double, (i,))?, i * 2);
+    ///     assert_eq!(program.call(&double, (i,))?, i * 2);
     /// }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn function(&self, name: &str) -> Option<Function<'p>> {
+    pub fn function<Args, Ret>(&self, name: &str) -> Option<Function<'p, Args, Ret>> {
         self.funcs.get(name).cloned().map(|(handle, signature)| {
-            let f = Function { handle, signature };
-            trace!("extracted `{}` handle: {:?}", name, f);
+            let f = Function {
+                handle,
+                signature,
+                types: PhantomData,
+            };
+            trace!("extracted `{}` handle: {:?}", name, &f.handle);
             f
         })
     }
@@ -393,7 +493,9 @@ impl<'p> Program<'p> {
     /// use purple_garden::{Pg, embed::Value};
     ///
     /// let mut program = Pg::new().compile(br#"fn add(a: Int b: Int) Int { a + b }"#)?;
-    /// let add = program.function("add").expect("function exists");
+    /// let add = program
+    ///     .function::<(i64, i64), i64>("add")
+    ///     .expect("function exists");
     ///
     /// let args: [Value; 2] = [40i64.into(), 2i64.into()];
     /// let ret = unsafe { program.call_unchecked(&add, &args)? };
@@ -408,16 +510,18 @@ impl<'p> Program<'p> {
     /// use purple_garden::{Pg, embed::Value};
     ///
     /// let mut program = Pg::new().compile(br#"fn identity(value: Int) Int { value }"#)?;
-    /// let identity = program.function("identity").expect("function exists");
+    /// let identity = program
+    ///     .function::<(i64,), i64>("identity")
+    ///     .expect("function exists");
     ///
     /// let ret = unsafe { program.call_unchecked(&identity, &[42i64.into()])? };
     /// assert_eq!(ret.as_int(), 42);
     /// assert_ne!(ret.as_f64(), 42.0);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub unsafe fn call_unchecked(
+    pub unsafe fn call_unchecked<Args, Ret>(
         &mut self,
-        function: &Function,
+        function: &Function<'_, Args, Ret>,
         args: &[Value],
     ) -> Result<Value, Anomaly> {
         self.vm.reset();
@@ -451,7 +555,9 @@ impl<'p> Program<'p> {
     ///
     /// Arguments are a tuple, a single argument is therefore `(T,)`. Argument count, argument
     /// types and the return type are checked against the declared signature before the call
-    /// happens, a mismatch produces Err([`Anomaly`])
+    /// happens, a mismatch produces Err([`CallError`]). The Rust signature is
+    /// selected when retrieving the function with [`Program::function`], so it
+    /// is inferred here.
     ///
     /// # Examples
     ///
@@ -459,8 +565,8 @@ impl<'p> Program<'p> {
     /// use purple_garden::Pg;
     ///
     /// let mut program = Pg::new().compile(br#"fn add(a: Int b: Int) Int { a + b }"#)?;
-    /// let add = program.function("add").expect("function exists");
-    /// assert_eq!(program.call::<_, i64>(&add, (40i64, 2i64))?, 42);
+    /// let add = program.function::<_, i64>("add").expect("function exists");
+    /// assert_eq!(program.call(&add, (40i64, 2i64))?, 42);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
@@ -475,8 +581,8 @@ impl<'p> Program<'p> {
     /// import "io"
     /// fn log(value: Int) { io.println(value) }
     /// "#)?;
-    /// let log = program.function("log").expect("function exists");
-    /// program.call::<_, ()>(&log, (42i64,))?;
+    /// let log = program.function::<_, ()>("log").expect("function exists");
+    /// program.call(&log, (42i64,))?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
@@ -486,57 +592,31 @@ impl<'p> Program<'p> {
     /// use purple_garden::Pg;
     ///
     /// let mut program = Pg::new().compile(br#"fn add(a: Int b: Int) Int { a + b }"#)?;
-    /// let add = program.function("add").expect("function exists");
+    /// let wrong_return = program.function::<_, f64>("add").expect("function exists");
+    /// let wrong_arity = program.function::<(i64,), i64>("add").expect("function exists");
+    /// let wrong_argument = program
+    ///     .function::<(i64, f64), i64>("add")
+    ///     .expect("function exists");
     ///
-    /// assert!(program.call::<_, f64>(&add, (40i64, 2i64)).is_err());
-    /// assert!(program.call::<_, i64>(&add, (40i64,)).is_err());
-    /// assert!(program.call::<_, i64>(&add, (40i64, 2.0f64)).is_err());
+    /// assert!(program.call(&wrong_return, (40i64, 2i64)).is_err());
+    /// assert!(program.call(&wrong_arity, (40i64,)).is_err());
+    /// assert!(program.call(&wrong_argument, (40i64, 2.0f64)).is_err());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn call<'vm, Args, Ret>(
         &'vm mut self,
-        function: &Function,
+        function: &Function<'_, Args, Ret>,
         args: Args,
-    ) -> Result<Ret, Anomaly>
+    ) -> Result<Ret, CallError>
     where
         Args: CallArgs,
         Ret: PgType + FromVm<'vm>,
     {
-        let signature = &function.signature;
-        let pc_or_fallback = match function.handle {
-            CcCallTarget::Bc { pc } => pc,
-            CcCallTarget::Native { .. } => 0,
-        };
-
-        if Ret::TYPE != signature.ret {
-            return Err(Anomaly::Msg {
-                msg: "Return type provided does not match the purple garden functions return type",
-                pc: pc_or_fallback,
-            });
-        }
-
-        let as_types = Args::TYPES;
-        if as_types.len() != signature.args.len() {
-            return Err(Anomaly::Msg {
-                msg: "Provided argument count does not match the purple garden functions argument count",
-                pc: pc_or_fallback,
-            });
-        }
-
-        for (i, arg) in as_types.iter().enumerate() {
-            let expected_type = &signature.args[i].1;
-            if arg != expected_type {
-                return Err(Anomaly::Msg {
-                    msg: "Provided arguments type does not match the type of the purple garden functions argument",
-                    // TODO: i need to improve the errors here
-                    // msg: &format!("argument {i} is {expected_type}, not {arg}"),
-                    pc: pc_or_fallback,
-                });
-            }
-        }
+        function.verify_signature()?;
 
         let args = args.inner(&mut self.vm);
-        let ret = unsafe { self.call_unchecked(function, args.as_ref())? };
+        let ret =
+            unsafe { self.call_unchecked(function, args.as_ref()) }.map_err(CallError::Runtime)?;
         let result = Ret::from_vm(&self.vm, ret);
         Ok(result)
     }
@@ -657,5 +737,55 @@ mod tests {
             assert!(program.funcs.contains_key("unused"));
             assert!(!program.funcs.contains_key("entry"));
         }
+    }
+
+    #[test]
+    fn call_error_reports_signature_mismatches_and_runtime_traps() {
+        let mut config = config::Config::default();
+        config.no_jit = true;
+        let mut program = Pg::new()
+            .config(config)
+            .compile(b"fn divide(a: Int b: Int) Int { a / b }")
+            .expect("program should compile");
+
+        let wrong_return = program
+            .function::<(i64, i64), f64>("divide")
+            .expect("function exists");
+        assert!(matches!(
+            program.call(&wrong_return, (1i64, 1i64)),
+            Err(CallError::ReturnType { expected, actual })
+                if expected == "Int" && actual == "Double"
+        ));
+
+        let wrong_arity = program
+            .function::<(i64,), i64>("divide")
+            .expect("function exists");
+        assert!(matches!(
+            program.call(&wrong_arity, (1i64,)),
+            Err(CallError::ArgumentCount {
+                expected: 2,
+                actual: 1
+            })
+        ));
+
+        let wrong_argument = program
+            .function::<(i64, f64), i64>("divide")
+            .expect("function exists");
+        assert!(matches!(
+            program.call(&wrong_argument, (1i64, 1.0f64)),
+            Err(CallError::ArgumentType {
+                index: 1,
+                expected,
+                actual
+            }) if expected == "Int" && actual == "Double"
+        ));
+
+        let divide = program
+            .function::<_, i64>("divide")
+            .expect("function exists");
+        assert!(matches!(
+            program.call(&divide, (1i64, 0i64)),
+            Err(CallError::Runtime(Anomaly::DivisionByZero { .. }))
+        ));
     }
 }


### PR DESCRIPTION
This pr:

- vendors raylib into `vendor/exp/raylib`
- add both rust and purple garden bindings for raylib
- reproducibly via nix flake
- std does not depend on vendor, only cli does since its the interpreter entrypoint

Enabling the following garden script:

```garden
import (
    "vendor/exp/raylib"
)

let width = 1024
let height = 512

#! create a raylib color from a rgb input
fn color(r:Int g:Int b:Int) Record<r:Int g:Int b:Int a:Int> {
  {r: r g: g b: b a: 255}
}

#! render a single frame
fn frame(width: Int height: Int) Void {
    raylib.begin_drawing()
    raylib.clear_background(color(30 30 30))
    let font_size = 64
    let text_width = raylib.measure_text("purple-garden" font_size)
    raylib.draw_text("purple-garden" (width - text_width) / 2 height/2 font_size color(0 188 212))
    raylib.end_drawing()
}

fn render(width: Int height: Int) Void {
  match {
      raylib.should_close() { raylib.close() }
      {
        frame(width height)
        render(width height)
      }
  }
}

raylib.init(width height "Hello from raylib in purple garden")
raylib.set_target_fps(240)
render(width height)
```