### PR TITLE
jit/x86: add emit_abi_call

### DIFF
--- a/examples/jitprogress.garden
+++ b/examples/jitprogress.garden
@@ -35,3 +35,14 @@ testing.assert(divs(42 17) == 8)
 testing.assert(absish(0) == 1)
 testing.assert(absish(5) == 2)
 testing.assert(factorial(20 1) == 2432902008176640000)
+
+#! create a color record from rgb
+fn C(r:Int g:Int b:Int) Record<r:Int g:Int b:Int a:Int> {
+  {r: r g: g b: b a: 255}
+}
+
+let c = C(1 2 3)
+testing.assert(c.r == 1)
+testing.assert(c.g == 2)
+testing.assert(c.b == 3)
+testing.assert(c.a == 255)

--- a/purple-garden-jit/src/lib.rs
+++ b/purple-garden-jit/src/lib.rs
@@ -190,6 +190,95 @@ mod tests_x86 {
         assert_eq!(run(jit.code(), [0, 0, 0])[0], 42);
     }
 
+    /// Allocation is a helper call: values used after it must survive the
+    /// caller-saved register clobber. This also exercises the VM-pointer ABI
+    /// and writing the returned payload.
+    #[test]
+    fn alloc_preserves_live_values_across_helper_call() {
+        use purple_garden_runtime::{Vm, VmConfig};
+        use std::alloc::Layout;
+
+        let record_ty = Type::record(vec![
+            ("r", Type::Int),
+            ("g", Type::Int),
+            ("b", Type::Int),
+            ("a", Type::Int),
+        ]);
+        let mut func = Func::new(
+            "alloc_live",
+            Id(0),
+            vec![Id(0), Id(1), Id(2)],
+            Some(record_ty.clone()),
+        );
+        let params = func.intern_params(vec![Id(0), Id(1), Id(2)]);
+        let alloc_id = Id(3);
+        func.blocks.push(Block {
+            tombstone: false,
+            id: Id(0),
+            params,
+            instructions: vec![
+                Instr::Alloc {
+                    dst: TypeId {
+                        id: alloc_id,
+                        ty: record_ty.clone(),
+                    },
+                    layout: Layout::from_size_align(32, 8).unwrap(),
+                    span: 0,
+                },
+                Instr::Store {
+                    src: Id(0),
+                    base: alloc_id,
+                    offset: 0,
+                    span: 0,
+                },
+                Instr::Store {
+                    src: Id(1),
+                    base: alloc_id,
+                    offset: 8,
+                    span: 0,
+                },
+                Instr::Store {
+                    src: Id(2),
+                    base: alloc_id,
+                    offset: 16,
+                    span: 0,
+                },
+                Instr::LoadConst {
+                    dst: TypeId {
+                        id: Id(4),
+                        ty: Type::Int,
+                    },
+                    value: Const::Int(255),
+                    span: 0,
+                },
+                Instr::Store {
+                    src: Id(4),
+                    base: alloc_id,
+                    offset: 24,
+                    span: 0,
+                },
+            ],
+            term: Some(Terminator::Return {
+                value: Some(alloc_id),
+                span: 0,
+            }),
+        });
+
+        let mut jit = Jit::new();
+        jit.compile_func(&func).expect("jit function");
+        let mut vm = Vm::new(VmConfig {
+            no_gc: true,
+            ..VmConfig::default()
+        });
+        let slots = unsafe { &mut *(&mut vm as *mut Vm as *mut [u64; 64]) };
+        slots[0..3].copy_from_slice(&[1, 2, 3]);
+        let page = ExecPage::new(jit.code()).expect("executable JIT page");
+        let f: unsafe extern "C" fn(*mut u64) = unsafe { std::mem::transmute(page.as_ptr()) };
+        unsafe { f(&mut vm as *mut Vm as *mut u64) };
+        let payload = unsafe { std::slice::from_raw_parts(slots[0] as *const u64, 4) };
+        assert_eq!(payload, &[1, 2, 3, 255]);
+    }
+
     #[test]
     fn compiles_tail_recursive_factorial_loop() {
         let mut func = Func::new("factorial", Id(0), vec![Id(0), Id(1)], Some(Type::Int));

--- a/purple-garden-jit/src/x86/mod.rs
+++ b/purple-garden-jit/src/x86/mod.rs
@@ -52,12 +52,16 @@ const RSP: u8 = 4;
 const RAX: u8 = 0;
 const RCX: u8 = 1;
 const RDX: u8 = 2;
+const RSI: u8 = 6;
+const R8: u8 = 8;
+const R9: u8 = 9;
 /// Registers implicitly clobbered by the current `idiv` lowering.
 const IDIV_CLOBBERS: &[u8] = &[RAX, RCX, RDX];
 
 #[derive(Default)]
 struct SupportPlan {
     entry: Option<ir::Id>,
+    call_sites: Vec<u32>,
     /// Target-specific register hazards discovered before allocation. Each
     /// entry says that a lowering at `pos` overwrites `regs`; the allocator then
     /// avoids assigning live-across values to those registers.
@@ -98,7 +102,7 @@ pub fn compile_func(
 
     let regs = allocator.rebuild(
         liveness,
-        &[],
+        &plan.call_sites,
         &plan.fixed_clobbers,
         crate::regalloc::RegClasses {
             caller: POOL,
@@ -594,11 +598,36 @@ fn emit_bin(out: &mut Vec<u8>, op: BinOp, d: u8, l: u8, r: u8) {
 /// C-ABI `call addr`, rdi already holding `*mut Vm`. Leaves enter at `rsp % 16
 /// == 8`, so realign with `sub`/`add rsp, 8`. Callees clobber caller-saved regs,
 /// fine here: the only use is a trap callback that returns right after.
-fn emit_abi_call(out: &mut Vec<u8>, addr: u64) {
+#[derive(Clone, Copy)]
+enum AbiArg {
+    Reg(u8),
+    Imm(u64),
+}
+
+/// Emit a small SysV ABI call. The VM base in `rdi` is saved because it is
+/// caller-saved, while the generated code continues using it after the call.
+fn emit_abi_call(out: &mut Vec<u8>, addr: u64, args: &[AbiArg], result: Option<u8>) {
     emit(out, Insn::SubImm { dst: RSP, imm: 8 });
+    emit(out, Insn::StoreMem { base: RSP, offset: 0, src: RDI });
+
+    let abi_regs = [RDI, RSI, RDX, RCX, R8, R9];
+    for (i, arg) in args.iter().enumerate() {
+        let Some(&dst) = abi_regs.get(i) else { return };
+        match *arg {
+            AbiArg::Reg(src) if src != dst => emit(out, Insn::Mov { dst, src }),
+            AbiArg::Imm(value) => emit(out, Insn::MovAbs { dst, imm: value }),
+            AbiArg::Reg(_) => {}
+        }
+    }
     emit(out, Insn::MovAbs { dst: 0, imm: addr }); // rax = addr
     emit(out, Insn::CallReg { reg: 0 }); // call rax
+    emit(out, Insn::LoadMem { dst: RDI, base: RSP, offset: 0 });
     emit(out, Insn::AddImm { dst: RSP, imm: 8 });
+    if let Some(dst) = result {
+        if dst != RAX {
+            emit(out, Insn::Mov { dst, src: RAX });
+        }
+    }
 }
 
 /// `d = l <op> imm` for IDiv/IMod, nonzero constant divisor. idiv has no imm
@@ -762,6 +791,9 @@ fn validate_supported(func: &ir::Func<'_>) -> Option<SupportPlan> {
 
         for instr in &block.instructions {
             match instr {
+                ir::Instr::Alloc { .. } => {
+                    plan.call_sites.push(pos);
+                }
                 ir::Instr::Noop => {}
                 ir::Instr::LoadConst { value, .. } if supported_const(value) => {}
                 ir::Instr::BinImm { op, imm, .. } if supported_bin_imm(*op) => {
@@ -876,6 +908,21 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
     fn emit_instr(&mut self, instr: &ir::Instr<'_>) -> Option<()> {
         match instr {
             ir::Instr::Noop => {}
+            ir::Instr::Alloc { dst: ir::TypeId { id, ty }, layout, .. } => {
+                let Some(dst_reg) = reg_of(self.regs, *id) else {
+                    skip!(self.func, "unallocated alloc dst %v{}", id.0);
+                };
+                let Some(kind) = purple_garden_runtime::AllocType::from_ty(ty) else {
+                    skip!(self.func, "unsupported allocation type");
+                };
+                emit_abi_call(
+                    self.out,
+                    purple_garden_runtime::jit_alloc as *const () as usize as u64,
+                    &[AbiArg::Reg(RDI), AbiArg::Imm(kind as u64),
+                      AbiArg::Imm(layout.size() as u64), AbiArg::Imm(layout.align() as u64)],
+                    Some(dst_reg),
+                );
+            }
             ir::Instr::LoadConst { dst, value, .. } => self.emit_const(dst, value)?,
             ir::Instr::BinImm {
                 op, dst, lhs, imm, ..
@@ -962,7 +1009,7 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
             BinOp::IDiv | BinOp::IMod if imm == 0 => {
                 let helper: purple_garden_runtime::BuiltinFn =
                     purple_garden_runtime::jit_trap_div_zero;
-                emit_abi_call(self.out, helper as usize as u64);
+                emit_abi_call(self.out, helper as usize as u64, &[AbiArg::Reg(RDI)], None);
                 emit(self.out, Insn::Ret);
             }
             BinOp::IMod if imm == 2 => {

--- a/purple-garden-jit/src/x86/mod.rs
+++ b/purple-garden-jit/src/x86/mod.rs
@@ -117,7 +117,15 @@ pub fn compile_func(
             .iter()
             .any(|loc| matches!(loc, ir::Location::Reg(r) if r == candidate))
     });
-    Lowering::new(func, out, regs, scratch, entry).emit()?;
+    let saved_regs = POOL_CALLEE
+        .iter()
+        .copied()
+        .filter(|&candidate| {
+            regs.iter()
+                .any(|loc| matches!(loc, ir::Location::Reg(r) if *r == candidate))
+        })
+        .collect();
+    Lowering::new(func, out, regs, scratch, entry, saved_regs).emit()?;
 
     // we have produced no machine code, so we just RET, this may be the case for fully optimised
     // (dce) away IR
@@ -273,6 +281,13 @@ pub enum Insn {
     CallReg {
         reg: u8,
     },
+    /// `push r{reg}` / `pop r{reg}` (callee-save frame management).
+    Push {
+        reg: u8,
+    },
+    Pop {
+        reg: u8,
+    },
     /// `cqo`; sign-extend rax into rdx:rax (the idiv dividend).
     Cqo,
     /// `idiv r{divisor}`; rdx:rax / divisor, quotient to rax, remainder to rdx.
@@ -356,6 +371,18 @@ impl Insn {
                     code.push(0x41);
                 }
                 code.extend_from_slice(&[0xff, modrm(2, reg)]);
+            }
+            Insn::Push { reg } => {
+                if reg >= 8 {
+                    code.push(0x41);
+                }
+                code.push(0x50 + (reg & 7));
+            }
+            Insn::Pop { reg } => {
+                if reg >= 8 {
+                    code.push(0x41);
+                }
+                code.push(0x58 + (reg & 7));
             }
             // REX.W 0x99 ; cqo.
             Insn::Cqo => code.extend_from_slice(&[0x48, 0x99]),
@@ -451,6 +478,8 @@ impl fmt::Display for Insn {
             Insn::Sete { dst } => write!(f, "sete {}b", r(dst)),
             Insn::MovAbs { dst, imm } => write!(f, "movabs {}, {imm:#x}", r(dst)),
             Insn::CallReg { reg } => write!(f, "call {}", r(reg)),
+            Insn::Push { reg } => write!(f, "push {}", r(reg)),
+            Insn::Pop { reg } => write!(f, "pop {}", r(reg)),
             Insn::Cqo => write!(f, "cqo"),
             Insn::Idiv { divisor } => write!(f, "idiv {}", r(divisor)),
         }
@@ -606,9 +635,28 @@ enum AbiArg {
 
 /// Emit a small SysV ABI call. The VM base in `rdi` is saved because it is
 /// caller-saved, while the generated code continues using it after the call.
-fn emit_abi_call(out: &mut Vec<u8>, addr: u64, args: &[AbiArg], result: Option<u8>) {
-    emit(out, Insn::SubImm { dst: RSP, imm: 8 });
-    emit(out, Insn::StoreMem { base: RSP, offset: 0, src: RDI });
+fn emit_abi_call(
+    out: &mut Vec<u8>,
+    addr: u64,
+    args: &[AbiArg],
+    result: Option<u8>,
+    stack_bytes: i32,
+) {
+    emit(
+        out,
+        Insn::SubImm {
+            dst: RSP,
+            imm: stack_bytes,
+        },
+    );
+    emit(
+        out,
+        Insn::StoreMem {
+            base: RSP,
+            offset: 0,
+            src: RDI,
+        },
+    );
 
     let abi_regs = [RDI, RSI, RDX, RCX, R8, R9];
     for (i, arg) in args.iter().enumerate() {
@@ -621,8 +669,21 @@ fn emit_abi_call(out: &mut Vec<u8>, addr: u64, args: &[AbiArg], result: Option<u
     }
     emit(out, Insn::MovAbs { dst: 0, imm: addr }); // rax = addr
     emit(out, Insn::CallReg { reg: 0 }); // call rax
-    emit(out, Insn::LoadMem { dst: RDI, base: RSP, offset: 0 });
-    emit(out, Insn::AddImm { dst: RSP, imm: 8 });
+    emit(
+        out,
+        Insn::LoadMem {
+            dst: RDI,
+            base: RSP,
+            offset: 0,
+        },
+    );
+    emit(
+        out,
+        Insn::AddImm {
+            dst: RSP,
+            imm: stack_bytes,
+        },
+    );
     if let Some(dst) = result {
         if dst != RAX {
             emit(out, Insn::Mov { dst, src: RAX });
@@ -841,6 +902,8 @@ struct Lowering<'a, 'ir> {
     out: &'a mut Vec<u8>,
     regs: &'a [ir::Location],
     scratch: Option<u8>,
+    /// Callee-saved GPRs used by this function, saved in the prologue.
+    saved_regs: Vec<u8>,
     entry: ir::Id,
     block_offsets: Vec<usize>,
     patches: Vec<Patch>,
@@ -855,12 +918,14 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
         regs: &'a [ir::Location],
         scratch: Option<u8>,
         entry: ir::Id,
+        saved_regs: Vec<u8>,
     ) -> Self {
         Self {
             func,
             out,
             regs,
             scratch,
+            saved_regs,
             entry,
             block_offsets: vec![usize::MAX; func.blocks.len()],
             patches: Vec::new(),
@@ -870,6 +935,7 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
 
     /// Emit the full function body, then patch deferred branch displacements.
     fn emit(mut self) -> Option<()> {
+        self.emit_prologue();
         self.emit_entry_loads();
 
         for block in &self.func.blocks {
@@ -886,6 +952,29 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
         }
 
         self.patch_jumps()
+    }
+
+    fn emit_prologue(&mut self) {
+        for &reg in &self.saved_regs {
+            emit(self.out, Insn::Push { reg });
+        }
+    }
+
+    fn emit_epilogue(&mut self) {
+        for &reg in self.saved_regs.iter().rev() {
+            emit(self.out, Insn::Pop { reg });
+        }
+        emit(self.out, Insn::Ret);
+    }
+
+    /// The call-local area contains the saved VM base. Its size also restores
+    /// the required 16-byte stack alignment before `call`.
+    fn abi_call_stack_bytes(&self) -> i32 {
+        if self.saved_regs.len() % 2 == 0 {
+            8
+        } else {
+            16
+        }
     }
 
     /// Load function parameters from `vm.r` slots into allocated registers.
@@ -908,7 +997,11 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
     fn emit_instr(&mut self, instr: &ir::Instr<'_>) -> Option<()> {
         match instr {
             ir::Instr::Noop => {}
-            ir::Instr::Alloc { dst: ir::TypeId { id, ty }, layout, .. } => {
+            ir::Instr::Alloc {
+                dst: ir::TypeId { id, ty },
+                layout,
+                ..
+            } => {
                 let Some(dst_reg) = reg_of(self.regs, *id) else {
                     skip!(self.func, "unallocated alloc dst %v{}", id.0);
                 };
@@ -918,9 +1011,14 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
                 emit_abi_call(
                     self.out,
                     purple_garden_runtime::jit_alloc as *const () as usize as u64,
-                    &[AbiArg::Reg(RDI), AbiArg::Imm(kind as u64),
-                      AbiArg::Imm(layout.size() as u64), AbiArg::Imm(layout.align() as u64)],
+                    &[
+                        AbiArg::Reg(RDI),
+                        AbiArg::Imm(kind as u64),
+                        AbiArg::Imm(layout.size() as u64),
+                        AbiArg::Imm(layout.align() as u64),
+                    ],
                     Some(dst_reg),
+                    self.abi_call_stack_bytes(),
                 );
             }
             ir::Instr::LoadConst { dst, value, .. } => self.emit_const(dst, value)?,
@@ -1009,8 +1107,14 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
             BinOp::IDiv | BinOp::IMod if imm == 0 => {
                 let helper: purple_garden_runtime::BuiltinFn =
                     purple_garden_runtime::jit_trap_div_zero;
-                emit_abi_call(self.out, helper as usize as u64, &[AbiArg::Reg(RDI)], None);
-                emit(self.out, Insn::Ret);
+                emit_abi_call(
+                    self.out,
+                    helper as usize as u64,
+                    &[AbiArg::Reg(RDI)],
+                    None,
+                    self.abi_call_stack_bytes(),
+                );
+                self.emit_epilogue();
             }
             BinOp::IMod if imm == 2 => {
                 if d != l {
@@ -1107,7 +1211,7 @@ impl<'a, 'ir> Lowering<'a, 'ir> {
             };
             emit(self.out, Insn::StoreSlot { src: r, slot: 0 });
         }
-        emit(self.out, Insn::Ret);
+        self.emit_epilogue();
         Some(())
     }
 


### PR DESCRIPTION
This stems from the need of jit compiling `Ir::Alloc`, which requires invoking the `purple_garden_runtime::jit_helpers::jit_alloc` defined as:

```rust
pub unsafe extern "C" fn jit_alloc(
    vm: *mut c_void,
    alloc_type: u8,
    size: usize,
    align: usize,
) -> *mut u8 {
```

Compiling now works for `color`:

```garden
import "testing"
fn color(r:Int g:Int b:Int) Record<r:Int g:Int b:Int a:Int> {
  {r: r g: g b: b a: 255}
}
let c = color(1 2 3)
testing.assert(c.r == 1)
testing.assert(c.g == 2)
testing.assert(c.b == 3)
testing.assert(c.a == 255)
```

Producing the following machine code:

```asm
0000000000000000 <jit_color>:
   0:	48 8b 5f 00          	mov    0x0(%rdi),%rbx
   4:	4c 8b 67 08          	mov    0x8(%rdi),%r12
   8:	4c 8b 6f 10          	mov    0x10(%rdi),%r13
   c:	48 81 ec 08 00 00 00 	sub    $0x8,%rsp
  13:	48 89 7c 24 00       	mov    %rdi,0x0(%rsp)
  18:	48 be 00 00 00 00 00 	movabs $0x0,%rsi
  1f:	00 00 00 
  22:	48 ba 20 00 00 00 00 	movabs $0x20,%rdx
  29:	00 00 00 
  2c:	48 b9 08 00 00 00 00 	movabs $0x8,%rcx
  33:	00 00 00 
  36:	48 b8 90 cf 37 4d 35 	movabs $0x56354d37cf90,%rax
  3d:	56 00 00 
  40:	ff d0                	call   *%rax
  42:	48 8b 7c 24 00       	mov    0x0(%rsp),%rdi
  47:	48 81 c4 08 00 00 00 	add    $0x8,%rsp
  4e:	48 89 58 00          	mov    %rbx,0x0(%rax)
  52:	4c 89 60 08          	mov    %r12,0x8(%rax)
  56:	4c 89 68 10          	mov    %r13,0x10(%rax)
  5a:	48 c7 c1 ff 00 00 00 	mov    $0xff,%rcx
  61:	48 89 48 18          	mov    %rcx,0x18(%rax)
  65:	48 89 47 00          	mov    %rax,0x0(%rdi)
  69:	c3                   	ret
```